### PR TITLE
Add RTLD_GLOBAL flag to dlopen

### DIFF
--- a/demo/main.c
+++ b/demo/main.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
     run_simple_string(six, code);
 
     // load the Directory check if available
-    six_pyobject_t *check = get_check(six, "datadog_checks.directory", "", "[[{directory: \"/\"}]");
+    six_pyobject_t *check = get_check(six, "datadog_checks.directory", "", "[{directory: \"/\"}]");
     if (check == NULL) {
         if (has_error(six)) {
             printf("%s\n", get_error(six));

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -31,7 +31,7 @@ six_t *make2() {
     }
 
     // load library
-    six_backend = dlopen(DATADOG_AGENT_TWO, RTLD_LAZY);
+    six_backend = dlopen(DATADOG_AGENT_TWO, RTLD_LAZY | RTLD_GLOBAL);
     if (!six_backend) {
         std::cerr << "Unable to open 'two' library: " << dlerror() << std::endl;
         return NULL;
@@ -58,7 +58,7 @@ six_t *make3() {
     }
 
     // load the library
-    six_backend = dlopen(DATADOG_AGENT_THREE, RTLD_LAZY);
+    six_backend = dlopen(DATADOG_AGENT_THREE, RTLD_LAZY | RTLD_GLOBAL);
     if (!six_backend) {
         std::cerr << "Unable to open 'three' library: " << dlerror() << std::endl;
         return NULL;


### PR DESCRIPTION
### What this PR does

Other wheel might dlopen other C library who depends on Python symbols
(such as prometheus_client wheel who use mmap library in Python
lib-dynload folder). Because of this, when loading Two or Three we need
to make the loaded symbols available for resolution for subsequently
loaded shared objects.

This also fix the wrongly formated yaml payload.

### Additional information

Datadog base check class now depends on `prometheus_client` who will load will use mmap lib (On linux: `lib-dynload/mmap.x86_64-linux-gnu.so`).

If `RTLD_GLOBAL` is not specify this lib will fail to be loaded with the following error:
```
ImportError: /home/dev/datadog-agent-six/venv2/lib/python2.7/lib-dynload/mmap.x86_64-linux-gnu.so: undefined symbol: PyExc_SystemError
```