### PR TITLE
some cleanup & additional windows

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -4,21 +4,8 @@
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_H_INCLUDED
 #define DATADOG_AGENT_SIX_H_INCLUDED
-#include <types.h>
+#include <six_types.h>
 
-#ifndef DATADOG_AGENT_SIX_API
-#    ifdef DATADOG_AGENT_SIX_TEST
-#        define DATADOG_AGENT_SIX_API
-#    elif _WIN32
-#        define DATADOG_AGENT_SIX_API __declspec(dllexport)
-#    else
-#        if __GNUC__ >= 4
-#            define DATADOG_AGENT_SIX_API __attribute__((visibility("default")))
-#        else
-#            define DATADOG_AGENT_SIX_API
-#        endif
-#    endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -6,7 +6,6 @@
 #define DATADOG_AGENT_SIX_H_INCLUDED
 #include <six_types.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/six.h
+++ b/include/six.h
@@ -8,7 +8,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
-#include "types.h"
+#include "six_types.h"
 
 // Opaque type to wrap PyObject
 class SixPyObject {};
@@ -41,6 +41,7 @@ public:
     const char *getError() const;
     bool hasError() const;
     void setError(const std::string &msg) const; // let const methods set errors
+    void setError(const char *msg) const; 
 
 protected:
     const char *getExtensionModuleName(six_module_t m);

--- a/include/six.h
+++ b/include/six.h
@@ -5,11 +5,11 @@
 #ifndef DATADOG_AGENT_SIX_SIX_H
 #define DATADOG_AGENT_SIX_SIX_H
 
+#include "six_types.h"
 #include <map>
 #include <mutex>
 #include <string>
 #include <vector>
-#include "six_types.h"
 
 // Opaque type to wrap PyObject
 class SixPyObject {};
@@ -42,7 +42,7 @@ public:
     const char *getError() const;
     bool hasError() const;
     void setError(const std::string &msg) const; // let const methods set errors
-    void setError(const char *msg) const; 
+    void setError(const char *msg) const;
 
 protected:
     const char *getExtensionModuleName(six_module_t m);

--- a/include/six_types.h
+++ b/include/six_types.h
@@ -9,7 +9,24 @@
 extern "C" {
 #endif
 
-typedef enum six_gilstate_e { DATADOG_AGENT_SIX_GIL_LOCKED, DATADOG_AGENT_SIX_GIL_UNLOCKED } six_gilstate_t;
+#ifndef DATADOG_AGENT_SIX_API
+#    ifdef DATADOG_AGENT_SIX_TEST
+#        define DATADOG_AGENT_SIX_API
+#    elif _WIN32
+#        define DATADOG_AGENT_SIX_API __declspec(dllexport)
+#    else
+#        if __GNUC__ >= 4
+#            define DATADOG_AGENT_SIX_API __attribute__((visibility("default")))
+#        else
+#            define DATADOG_AGENT_SIX_API
+#        endif
+#    endif
+#endif
+
+typedef enum six_gilstate_e { 
+    DATADOG_AGENT_SIX_GIL_LOCKED, 
+    DATADOG_AGENT_SIX_GIL_UNLOCKED 
+} six_gilstate_t;
 
 typedef enum six_module_func_e {
     DATADOG_AGENT_SIX_NOARGS,

--- a/include/six_types.h
+++ b/include/six_types.h
@@ -23,10 +23,7 @@ extern "C" {
 #    endif
 #endif
 
-typedef enum six_gilstate_e { 
-    DATADOG_AGENT_SIX_GIL_LOCKED, 
-    DATADOG_AGENT_SIX_GIL_UNLOCKED 
-} six_gilstate_t;
+typedef enum six_gilstate_e { DATADOG_AGENT_SIX_GIL_LOCKED, DATADOG_AGENT_SIX_GIL_UNLOCKED } six_gilstate_t;
 
 typedef enum six_module_func_e {
     DATADOG_AGENT_SIX_NOARGS,

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -167,15 +167,25 @@ void destroy(six_t *six) {
 }
 #endif
 
-int init(six_t *six, char *pythonHome) { return AS_TYPE(Six, six)->init(pythonHome) ? 1 : 0; }
+int init(six_t *six, char *pythonHome) {
+    return AS_TYPE(Six, six)->init(pythonHome) ? 1 : 0;
+}
 
-int is_initialized(six_t *six) { return AS_CTYPE(Six, six)->isInitialized(); }
+int is_initialized(six_t *six) {
+    return AS_CTYPE(Six, six)->isInitialized();
+}
 
-const char *get_py_version(const six_t *six) { return AS_CTYPE(Six, six)->getPyVersion(); }
+const char *get_py_version(const six_t *six) {
+    return AS_CTYPE(Six, six)->getPyVersion();
+}
 
-int run_simple_string(const six_t *six, const char *code) { return AS_CTYPE(Six, six)->runSimpleString(code) ? 1 : 0; }
+int run_simple_string(const six_t *six, const char *code) {
+    return AS_CTYPE(Six, six)->runSimpleString(code) ? 1 : 0;
+}
 
-six_pyobject_t *get_none(const six_t *six) { return AS_TYPE(six_pyobject_t, AS_CTYPE(Six, six)->getNone()); }
+six_pyobject_t *get_none(const six_t *six) {
+    return AS_TYPE(six_pyobject_t, AS_CTYPE(Six, six)->getNone());
+}
 
 int add_module_func(six_t *six, six_module_t module, six_module_func_t func_type, char *func_name, void *func) {
     return AS_TYPE(Six, six)->addModuleFunction(module, func_type, func_name, func) ? 1 : 0;
@@ -185,11 +195,17 @@ int add_module_int_const(six_t *six, six_module_t module, const char *name, long
     return AS_TYPE(Six, six)->addModuleIntConst(module, name, value) ? 1 : 0;
 }
 
-int add_python_path(six_t *six, const char *path) { return AS_TYPE(Six, six)->addPythonPath(path) ? 1 : 0; }
+int add_python_path(six_t *six, const char *path) {
+    return AS_TYPE(Six, six)->addPythonPath(path) ? 1 : 0;
+}
 
-six_gilstate_t ensure_gil(six_t *six) { return AS_TYPE(Six, six)->GILEnsure(); }
+six_gilstate_t ensure_gil(six_t *six) {
+    return AS_TYPE(Six, six)->GILEnsure();
+}
 
-void release_gil(six_t *six, six_gilstate_t state) { AS_TYPE(Six, six)->GILRelease(state); }
+void release_gil(six_t *six, six_gilstate_t state) {
+    AS_TYPE(Six, six)->GILRelease(state);
+}
 
 int get_check(six_t *six, const char *name, const char *init_config, const char *instances, six_pyobject_t **check,
               char **version) {
@@ -200,8 +216,14 @@ const char *run_check(six_t *six, six_pyobject_t *check) {
     return AS_TYPE(Six, six)->runCheck(AS_TYPE(SixPyObject, check));
 }
 
-int has_error(const six_t *six) { return AS_CTYPE(Six, six)->hasError() ? 1 : 0; }
+int has_error(const six_t *six) {
+    return AS_CTYPE(Six, six)->hasError() ? 1 : 0;
+}
 
-const char *get_error(const six_t *six) { return AS_CTYPE(Six, six)->getError(); }
+const char *get_error(const six_t *six) {
+    return AS_CTYPE(Six, six)->getError();
+}
 
-void clear_error(six_t *six) { AS_TYPE(Six, six)->clearError(); }
+void clear_error(six_t *six) {
+    AS_TYPE(Six, six)->clearError();
+}

--- a/six/six.cpp
+++ b/six/six.cpp
@@ -25,8 +25,8 @@ const char *Six::getExtensionModuleName(six_module_t m) {
     }
 }
 
-const char *Six::getUnknownModuleName() { 
-    return datadog_agent_six_unknown; 
+const char *Six::getUnknownModuleName() {
+    return datadog_agent_six_unknown;
 }
 
 void Six::setError(const std::string &msg) const {
@@ -50,8 +50,8 @@ const char *Six::getError() const {
     return _error.c_str();
 }
 
-bool Six::hasError() const { 
-    return _errorFlag; 
+bool Six::hasError() const {
+    return _errorFlag;
 }
 
 void Six::clearError() {

--- a/six/six.cpp
+++ b/six/six.cpp
@@ -25,9 +25,16 @@ const char *Six::getExtensionModuleName(six_module_t m) {
     }
 }
 
-const char *Six::getUnknownModuleName() { return datadog_agent_six_unknown; }
+const char *Six::getUnknownModuleName() { 
+    return datadog_agent_six_unknown; 
+}
 
 void Six::setError(const std::string &msg) const {
+    _errorFlag = true;
+    _error = msg;
+}
+
+void Six::setError(const char *msg) const {
     _errorFlag = true;
     _error = msg;
 }
@@ -43,7 +50,9 @@ const char *Six::getError() const {
     return _error.c_str();
 }
 
-bool Six::hasError() const { return _errorFlag; }
+bool Six::hasError() const { 
+    return _errorFlag; 
+}
 
 void Six::clearError() {
     _errorFlag = false;

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -9,10 +9,13 @@
 #include <algorithm>
 #include <sstream>
 
-extern "C" DATADOG_AGENT_SIX_API Six *  create() { return new Three(); }
+extern "C" DATADOG_AGENT_SIX_API Six *create() {
+    return new Three();
+}
 
-extern "C" DATADOG_AGENT_SIX_API void destroy(Six *p) { delete p; }
-
+extern "C" DATADOG_AGENT_SIX_API void destroy(Six *p) {
+    delete p;
+}
 
 PyModuleConstants Three::ModuleConstants;
 
@@ -106,16 +109,16 @@ bool Three::init(const char *pythonHome) {
     return _baseClass != NULL;
 }
 
-bool Three::isInitialized() const { 
-    return Py_IsInitialized(); 
+bool Three::isInitialized() const {
+    return Py_IsInitialized();
 }
 
-const char *Three::getPyVersion() const { 
-    return Py_GetVersion(); 
+const char *Three::getPyVersion() const {
+    return Py_GetVersion();
 }
 
-bool Three::runSimpleString(const char *code) const { 
-    return PyRun_SimpleString(code) == 0; 
+bool Three::runSimpleString(const char *code) const {
+    return PyRun_SimpleString(code) == 0;
 }
 
 bool Three::addModuleFunction(six_module_t module, six_module_func_t t, const char *funcName, void *func) {
@@ -264,7 +267,7 @@ done:
     return true;
 }
 
-// 
+//
 const char *Three::runCheck(SixPyObject *check) {
     if (check == NULL) {
         return NULL;
@@ -363,7 +366,7 @@ PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module) {
 
             // Clears exception and sets error
             PyException_SetTraceback(PyExc_IndexError, Py_None);
-            setError((const char*)PyBytes_AsString(reason));
+            setError((const char *)PyBytes_AsString(reason));
             goto done;
         }
 

--- a/three/three.h
+++ b/three/three.h
@@ -72,15 +72,4 @@ private:
     PyPaths _pythonPaths;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-extern  DATADOG_AGENT_SIX_API Six *  create() { return new Three(); }
-
-extern  DATADOG_AGENT_SIX_API void destroy(Six *p) { delete p; }
-
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/three/three.h
+++ b/three/three.h
@@ -53,7 +53,9 @@ public:
     bool isInitialized() const;
     const char *getPyVersion() const;
     bool runSimpleString(const char *path) const;
-    SixPyObject *getNone() const { return reinterpret_cast<SixPyObject *>(Py_None); }
+    SixPyObject *getNone() const {
+        return reinterpret_cast<SixPyObject *>(Py_None);
+    }
 
 private:
     PyObject *_importFrom(const char *module, const char *name);

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -10,8 +10,12 @@
 #include <iostream>
 #include <sstream>
 
-extern "C" DATADOG_AGENT_SIX_API Six *create() { return new Two(); }
-extern "C" DATADOG_AGENT_SIX_API void destroy(Six *p) { delete p; }
+extern "C" DATADOG_AGENT_SIX_API Six *create() {
+    return new Two();
+}
+extern "C" DATADOG_AGENT_SIX_API void destroy(Six *p) {
+    delete p;
+}
 
 Two::~Two() {
     Py_XDECREF(_baseClass);
@@ -60,16 +64,16 @@ bool Two::init(const char *pythonHome) {
     return true;
 }
 
-bool Two::isInitialized() const { 
-    return Py_IsInitialized(); 
+bool Two::isInitialized() const {
+    return Py_IsInitialized();
 }
 
-const char *Two::getPyVersion() const { 
-    return Py_GetVersion(); 
+const char *Two::getPyVersion() const {
+    return Py_GetVersion();
 }
 
-bool Two::runSimpleString(const char *code) const { 
-    return PyRun_SimpleString(code) == 0; 
+bool Two::runSimpleString(const char *code) const {
+    return PyRun_SimpleString(code) == 0;
 }
 
 bool Two::addModuleFunction(six_module_t module, six_module_func_t t, const char *funcName, void *func) {

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -10,6 +10,9 @@
 #include <iostream>
 #include <sstream>
 
+extern "C" DATADOG_AGENT_SIX_API Six *create() { return new Two(); }
+extern "C" DATADOG_AGENT_SIX_API void destroy(Six *p) { delete p; }
+
 Two::~Two() {
     Py_XDECREF(_baseClass);
     Py_Finalize();
@@ -57,11 +60,17 @@ bool Two::init(const char *pythonHome) {
     return true;
 }
 
-bool Two::isInitialized() const { return Py_IsInitialized(); }
+bool Two::isInitialized() const { 
+    return Py_IsInitialized(); 
+}
 
-const char *Two::getPyVersion() const { return Py_GetVersion(); }
+const char *Two::getPyVersion() const { 
+    return Py_GetVersion(); 
+}
 
-bool Two::runSimpleString(const char *code) const { return PyRun_SimpleString(code) == 0; }
+bool Two::runSimpleString(const char *code) const { 
+    return PyRun_SimpleString(code) == 0; 
+}
 
 bool Two::addModuleFunction(six_module_t module, six_module_func_t t, const char *funcName, void *func) {
     if (getExtensionModuleName(module) == getUnknownModuleName()) {
@@ -445,7 +454,7 @@ char *Two::_getCheckVersion(PyObject *module) const {
     // try getting module.__version__
     py_version = PyObject_GetAttrString(module, version_field);
     if (py_version != NULL && PyString_Check(py_version)) {
-        ret = strdup(PyString_AS_STRING(py_version));
+        ret = _strdup(PyString_AS_STRING(py_version));
         goto done;
     } else {
         // we expect __version__ might not be there, don't clutter the error stream

--- a/two/two.h
+++ b/two/two.h
@@ -11,19 +11,6 @@
 #include <Python.h>
 #include <six.h>
 
-#ifndef DATADOG_AGENT_SIX_API
-#    ifdef DATADOG_AGENT_SIX_TEST
-#        define DATADOG_AGENT_SIX_API
-#    elif _WIN32
-#        define DATADOG_AGENT_SIX_API __declspec(dllexport)
-#    else
-#        if __GNUC__ >= 4
-#            define DATADOG_AGENT_SIX_API __attribute__((visibility("default")))
-#        else
-#            define DATADOG_AGENT_SIX_API
-#        endif
-#    endif
-#endif
 
 class Two : public Six {
 public:
@@ -69,15 +56,4 @@ private:
     PyPaths _pythonPaths;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
- DATADOG_AGENT_SIX_API Six *create() { return new Two(); }
-
- DATADOG_AGENT_SIX_API void destroy(Six *p) { delete p; }
-
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/two/two.h
+++ b/two/two.h
@@ -11,7 +11,6 @@
 #include <Python.h>
 #include <six.h>
 
-
 class Two : public Six {
 public:
     Two()
@@ -37,7 +36,9 @@ public:
     bool isInitialized() const;
     const char *getPyVersion() const;
     bool runSimpleString(const char *code) const;
-    SixPyObject *getNone() const { return reinterpret_cast<SixPyObject *>(Py_None); }
+    SixPyObject *getNone() const {
+        return reinterpret_cast<SixPyObject *>(Py_None);
+    }
 
 private:
     PyObject *_importFrom(const char *module, const char *name);


### PR DESCRIPTION
Superset of previous PR; leaving those changes aside
- rename `types.h` to `six_types.h` to avoid collision with standard `sys/types.h`
- remove single line functions (readability)
- fix one leak (in error case) of allocating/not freeing error text
- fix leak in FindSubClassOf leaking each symbol name
- move create & destroy functions into `.cpp` file instead of header file to avoid duplicate symbols down the road.