### PR TITLE
[aggregator] submit_metric

### DIFF
--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -42,6 +42,9 @@ DATADOG_AGENT_SIX_API int run_simple_string(const six_t *, const char *code);
 DATADOG_AGENT_SIX_API int has_error(const six_t *);
 DATADOG_AGENT_SIX_API const char *get_error(const six_t *);
 
+// AGGREGATOR API
+DATADOG_AGENT_SIX_API void set_submit_metric_cb(six_t *, cb_submit_metric_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/six.h
+++ b/include/six.h
@@ -44,6 +44,9 @@ public:
     void setError(const std::string &msg) const; // let const methods set errors
     void setError(const char *msg) const;
 
+    // Aggregator API
+    virtual void setSubmitMetricCb(cb_submit_metric_t) = 0;
+
 protected:
     const char *getExtensionModuleName(six_module_t m);
     const char *getUnknownModuleName();

--- a/include/six_types.h
+++ b/include/six_types.h
@@ -46,6 +46,19 @@ typedef enum six_module_e {
     DATADOG_AGENT_SIX_UTIL,
 } six_module_t;
 
+typedef enum {
+    DATADOG_AGENT_SIX_GAUGE = 0,
+    DATADOG_AGENT_SIX_RATE,
+    DATADOG_AGENT_SIX_COUNT,
+    DATADOG_AGENT_SIX_MONOTONIC_COUNT,
+    DATADOG_AGENT_SIX_COUNTER,
+    DATADOG_AGENT_SIX_HISTOGRAM,
+    DATADOG_AGENT_SIX_HISTORATE
+} metric_type_t;
+
+// custom builtins
+typedef void (*cb_submit_metric_t)(char *, metric_type_t, char *, float, char **, int, char *);
+
 // these strings need to be alive for the whole interpreter lifetime because
 // they'll be used from the CPython Inittab. Be sure to keep these in sync
 // with `six_module_e` contents.

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -227,3 +227,7 @@ const char *get_error(const six_t *six) {
 void clear_error(six_t *six) {
     AS_TYPE(Six, six)->clearError();
 }
+
+void set_submit_metric_cb(six_t *six, cb_submit_metric_t cb) {
+    AS_TYPE(Six, six)->setSubmitMetricCb(cb);
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,7 +7,8 @@ TWO_PKGS = \
 THREE_PKGS = \
 	./three/... \
 	./three_extend/... \
-	./three_init/...
+	./three_init/... \
+	./three_aggregator
 
 all: test
 

--- a/test/three_aggregator/three_aggregator.go
+++ b/test/three_aggregator/three_aggregator.go
@@ -1,0 +1,87 @@
+package threeaggregator
+
+import (
+	"fmt"
+	"unsafe"
+
+	common "../common"
+)
+
+// #cgo CFLAGS: -I../../include
+// #cgo LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
+// #include <datadog_agent_six.h>
+//
+// extern void submitMetric(char *, metric_type_t, char *, float, char **, int, char *);
+// static void initAggregator(six_t *six) {
+//    set_submit_metric_cb(six, submitMetric);
+// }
+import "C"
+
+var (
+	six        *C.six_t
+	checkID    string
+	metricType int
+	name       string
+	value      float64
+	tags       []string
+	hostname   string
+)
+
+func resetOuputValues() {
+	checkID = ""
+	metricType = -1
+	name = ""
+	value = -1
+	tags = []string{}
+	hostname = ""
+}
+
+//export submitMetric
+func submitMetric(id *C.char, mt C.metric_type_t, mname *C.char, val C.float, t **C.char, tagsLen C.int, hname *C.char) {
+	checkID = C.GoString(id)
+	metricType = int(mt)
+	name = C.GoString(mname)
+	value = float64(val)
+	hostname = C.GoString(hname)
+	if t != nil {
+		for _, s := range (*[1 << 30]*C.char)(unsafe.Pointer(t))[:tagsLen:tagsLen] {
+			tags = append(tags, C.GoString(s))
+		}
+	}
+}
+
+func runSubmitMetric() (string, error) {
+	var err error
+	six = C.make3()
+	C.initAggregator(six)
+	// Updates sys.path so testing Check can be found
+	C.add_python_path(six, C.CString("../python"))
+	if ok := C.init(six, nil); ok != 1 {
+		return "", fmt.Errorf("`init` errored")
+	}
+
+	resetOuputValues()
+
+	code := C.CString(`
+try:
+	import aggregator
+	aggregator.submit_metric(None, 'id', aggregator.GAUGE, 'name', -99.0, ['foo', 'bar'], 'myhost')
+except Exception as e:
+	print(e, flush=True)
+	`)
+	var ret bool
+	var output []byte
+	output, err = common.Capture(func() {
+		ret = C.run_simple_string(six, code) == 1
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	if !ret {
+		return "", fmt.Errorf("`run_simple_string` errored")
+	}
+
+	return string(output), err
+}

--- a/test/three_aggregator/three_aggregator_test.go
+++ b/test/three_aggregator/three_aggregator_test.go
@@ -1,0 +1,35 @@
+package threeaggregator
+
+import "testing"
+
+func TestExtend(t *testing.T) {
+	out, err := runSubmitMetric()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+	if checkID != "id" {
+		t.Fatalf("Unexpected id value: %s", checkID)
+	}
+	if metricType != 0 {
+		t.Fatalf("Unexpected metricType value: %d", metricType)
+	}
+	if name != "name" {
+		t.Fatalf("Unexpected name value: %s", name)
+	}
+	if value != -99.0 {
+		t.Fatalf("Unexpected value: %f", value)
+	}
+	if hostname != "myhost" {
+		t.Fatalf("Unexpected hostname value: %s", hostname)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("Unexpected tags length: %d", len(tags))
+	}
+	if tags[0] != "foo" || tags[1] != "bar" {
+		t.Fatalf("Unexpected tags: %v", tags)
+	}
+}

--- a/three/CMakeLists.txt
+++ b/three/CMakeLists.txt
@@ -5,7 +5,7 @@ project(datadog-agent-three VERSION 0.1.0 DESCRIPTION "CPython backend for the D
 
 if(WIN32)
 # explicitly set the compiler flags to use the static C runtime (/MT(d) instead of the DLL
-# c runtime (/MD(d) so that we don't have to worry about redistributing the CRT).  
+# c runtime (/MD(d) so that we don't have to worry about redistributing the CRT).
 
 foreach(flag_var
         CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
@@ -21,6 +21,7 @@ configure_file(constants.h.in constants.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_library(datadog-agent-three SHARED
     three.cpp
+    aggregator.c
 )
 
 

--- a/three/aggregator.c
+++ b/three/aggregator.c
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+#include "aggregator.h"
+
+// these must be set by the Agent
+static cb_submit_metric_t cb_submit_metric = NULL;
+
+static PyMethodDef methods[] = {
+    { "submit_metric", (PyCFunction)submit_metric, METH_VARARGS, "Submit metrics to the aggregator." },
+    { "submit_service_check", (PyCFunction)submit_service_check, METH_VARARGS,
+      "Submit service checks to the aggregator." },
+    { "submit_event", (PyCFunction)submit_event, METH_VARARGS, "Submit events to the aggregator." },
+    { NULL, NULL } // guards
+};
+
+static struct PyModuleDef module_def = { PyModuleDef_HEAD_INIT, "aggregator", NULL, -1, methods };
+
+PyMODINIT_FUNC PyInit_aggregator(void) {
+    PyObject *m = PyModule_Create(&module_def);
+
+    PyModule_AddIntConstant(m, "GAUGE", DATADOG_AGENT_SIX_GAUGE);
+    PyModule_AddIntConstant(m, "COUNT", DATADOG_AGENT_SIX_COUNT);
+    PyModule_AddIntConstant(m, "MONOTONIC_COUNT", DATADOG_AGENT_SIX_MONOTONIC_COUNT);
+    PyModule_AddIntConstant(m, "COUNTER", DATADOG_AGENT_SIX_COUNTER);
+    PyModule_AddIntConstant(m, "HISTOGRAM", DATADOG_AGENT_SIX_HISTOGRAM);
+    PyModule_AddIntConstant(m, "HISTORATE", DATADOG_AGENT_SIX_HISTORATE);
+
+    return m;
+}
+
+void set_submit_metric_cb(cb_submit_metric_t cb) {
+    cb_submit_metric = cb;
+}
+
+static PyObject *submit_metric(PyObject *self, PyObject *args) {
+    PyObject *check = NULL;
+    PyObject *py_tags = NULL;
+    PyObject *py_tags_list = NULL;
+    char *err = NULL;
+    char *name = NULL;
+    char *hostname = NULL;
+    char *check_id = NULL;
+    char **tags = NULL;
+    int mt;
+    float value;
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname)
+    if (!PyArg_ParseTuple(args, "OsisfOs", &check, &check_id, &mt, &name, &value, &py_tags, &hostname)) {
+        goto done;
+    }
+
+    // convert tags to an array of char*
+    Py_ssize_t len = 0;
+    if (py_tags != NULL && PySequence_Check(py_tags)) {
+        len = PySequence_Length(py_tags);
+        if (len) {
+            py_tags_list = PySequence_Fast(py_tags, err);
+            if (py_tags_list == NULL) {
+                goto done;
+            }
+
+            tags = malloc(len * sizeof(char *));
+
+            for (int i = 0; i < len; i++) {
+                PyObject *item = PySequence_Fast_GET_ITEM(py_tags_list, i); // `item` is borrowed, no need to decref
+                // skip if not a string
+                if (!PyUnicode_Check(item)) {
+                    continue;
+                }
+                PyObject *temp_bytes = PyUnicode_AsEncodedString(item, "UTF-8", "strict");
+                tags[i] = _strdup(PyBytes_AS_STRING(temp_bytes));
+                Py_XDECREF(temp_bytes);
+            }
+        }
+    }
+
+    cb_submit_metric(check_id, mt, name, value, tags, len, hostname);
+
+done:
+    if (err != NULL) {
+        free(err);
+    }
+    Py_XDECREF(check);
+    Py_XDECREF(py_tags);
+    Py_XDECREF(py_tags_list);
+    PyGILState_Release(gstate);
+
+    return Py_None;
+}
+
+static PyObject *submit_service_check(PyObject *self, PyObject *args) {
+    /*FIXME*/
+    return NULL;
+}
+static PyObject *submit_event(PyObject *self, PyObject *args) {
+    /*FIXME*/
+    return NULL;
+}

--- a/three/aggregator.c
+++ b/three/aggregator.c
@@ -4,6 +4,8 @@
 // Copyright 2019 Datadog, Inc.
 #include "aggregator.h"
 
+#include <assert.h>
+
 // these must be set by the Agent
 static cb_submit_metric_t cb_submit_metric = NULL;
 
@@ -40,6 +42,9 @@ void _set_submit_metric_cb(cb_submit_metric_t cb) {
 }
 
 static PyObject *submit_metric(PyObject *self, PyObject *args) {
+    // callback must be set
+    assert(cb_submit_metric != NULL);
+
     PyObject *check = NULL;
     PyObject *py_tags = NULL;
     PyObject *py_tags_list = NULL;

--- a/three/aggregator.c
+++ b/three/aggregator.c
@@ -7,6 +7,11 @@
 // these must be set by the Agent
 static cb_submit_metric_t cb_submit_metric = NULL;
 
+// forward declarations
+static PyObject *submit_metric(PyObject *self, PyObject *args);
+static PyObject *submit_service_check(PyObject *self, PyObject *args);
+static PyObject *submit_event(PyObject *self, PyObject *args);
+
 static PyMethodDef methods[] = {
     { "submit_metric", (PyCFunction)submit_metric, METH_VARARGS, "Submit metrics to the aggregator." },
     { "submit_service_check", (PyCFunction)submit_service_check, METH_VARARGS,
@@ -30,7 +35,7 @@ PyMODINIT_FUNC PyInit_aggregator(void) {
     return m;
 }
 
-void set_submit_metric_cb(cb_submit_metric_t cb) {
+void _set_submit_metric_cb(cb_submit_metric_t cb) {
     cb_submit_metric = cb;
 }
 

--- a/three/aggregator.h
+++ b/three/aggregator.h
@@ -9,8 +9,14 @@
 
 PyMODINIT_FUNC PyInit_aggregator(void);
 
-static PyObject *submit_metric(PyObject *self, PyObject *args);
-static PyObject *submit_service_check(PyObject *self, PyObject *args);
-static PyObject *submit_event(PyObject *self, PyObject *args);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void _set_submit_metric_cb(cb_submit_metric_t);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/three/aggregator.h
+++ b/three/aggregator.h
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+#ifndef DATADOG_AGENT_SIX_THREE_AGGREGATOR_H
+#define DATADOG_AGENT_SIX_THREE_AGGREGATOR_H
+#include <Python.h>
+#include <six_types.h>
+
+PyMODINIT_FUNC PyInit_aggregator(void);
+
+static PyObject *submit_metric(PyObject *self, PyObject *args);
+static PyObject *submit_service_check(PyObject *self, PyObject *args);
+static PyObject *submit_event(PyObject *self, PyObject *args);
+
+#endif

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -527,5 +527,5 @@ done:
 }
 
 void Three::setSubmitMetricCb(cb_submit_metric_t cb) {
-    set_submit_metric_cb(cb);
+    _set_submit_metric_cb(cb);
 }

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -4,6 +4,7 @@
 // Copyright 2019 Datadog, Inc.
 #include "three.h"
 
+#include "aggregator.h"
 #include "constants.h"
 
 #include <algorithm>
@@ -56,7 +57,6 @@ PyModuleConstants Three::ModuleConstants;
 INIT_PYTHON_MODULE(DATADOG_AGENT_SIX_DATADOG_AGENT, datadog_agent)
 INIT_PYTHON_MODULE(DATADOG_AGENT_SIX__UTIL, _util)
 INIT_PYTHON_MODULE(DATADOG_AGENT_SIX_UTIL, util)
-INIT_PYTHON_MODULE(DATADOG_AGENT_SIX_AGGREGATOR, aggregator)
 INIT_PYTHON_MODULE(DATADOG_AGENT_SIX_CONTAINERS, containers)
 INIT_PYTHON_MODULE(DATADOG_AGENT_SIX_KUBEUTIL, kubeutil)
 INIT_PYTHON_MODULE(DATADOG_AGENT_SIX_TAGGER, tagger)
@@ -75,10 +75,11 @@ bool Three::init(const char *pythonHome) {
     APPEND_TO_PYTHON_INITTAB(DATADOG_AGENT_SIX_DATADOG_AGENT, datadog_agent)
     APPEND_TO_PYTHON_INITTAB(DATADOG_AGENT_SIX__UTIL, _util)
     APPEND_TO_PYTHON_INITTAB(DATADOG_AGENT_SIX_UTIL, util)
-    APPEND_TO_PYTHON_INITTAB(DATADOG_AGENT_SIX_AGGREGATOR, aggregator)
     APPEND_TO_PYTHON_INITTAB(DATADOG_AGENT_SIX_CONTAINERS, containers)
     APPEND_TO_PYTHON_INITTAB(DATADOG_AGENT_SIX_KUBEUTIL, kubeutil)
     APPEND_TO_PYTHON_INITTAB(DATADOG_AGENT_SIX_TAGGER, tagger)
+
+    PyImport_AppendInittab("aggregator", PyInit_aggregator);
 
     if (pythonHome == NULL) {
         _pythonHome = Py_DecodeLocale(_defaultPythonHome, NULL);
@@ -523,4 +524,8 @@ done:
     Py_XDECREF(py_version);
     Py_XDECREF(py_version_bytes);
     return ret;
+}
+
+void Three::setSubmitMetricCb(cb_submit_metric_t cb) {
+    set_submit_metric_cb(cb);
 }

--- a/three/three.h
+++ b/three/three.h
@@ -57,6 +57,9 @@ public:
         return reinterpret_cast<SixPyObject *>(Py_None);
     }
 
+    // Aggregator API
+    void setSubmitMetricCb(cb_submit_metric_t);
+
 private:
     PyObject *_importFrom(const char *module, const char *name);
     PyObject *_findSubclassOf(PyObject *base, PyObject *module);
@@ -72,5 +75,9 @@ private:
     PyObject *_baseClass;
     PyPaths _pythonPaths;
 };
+
+extern "C" {
+void set_submit_metric_cb(cb_submit_metric_t);
+}
 
 #endif

--- a/two/two.h
+++ b/two/two.h
@@ -40,6 +40,10 @@ public:
         return reinterpret_cast<SixPyObject *>(Py_None);
     }
 
+    // Aggregator API
+    void setSubmitMetricCb(cb_submit_metric_t) {
+    }
+
 private:
     PyObject *_importFrom(const char *module, const char *name);
     PyObject *_findSubclassOf(PyObject *base, PyObject *moduleName);


### PR DESCRIPTION
First part of the custom builtin `aggregator`, this approach isolates the Go code from using any bit of the CPython API, the heavy lift is done by the C module `aggregator.c`.

WIP:
* ~memory management~
* ~only tested on Mac~