### PR TITLE
Memory management API

### DIFF
--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -33,6 +33,7 @@ DATADOG_AGENT_SIX_API void release_gil(six_t *, six_gilstate_t);
 DATADOG_AGENT_SIX_API int get_check(six_t *, const char *name, const char *init_config, const char *instances,
                                     six_pyobject_t **check, char **version);
 DATADOG_AGENT_SIX_API const char *run_check(six_t *, six_pyobject_t *check);
+DATADOG_AGENT_SIX_API void six_free(six_t *, void *ptr);
 
 // C CONST API
 DATADOG_AGENT_SIX_API int is_initialized(six_t *);

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -34,6 +34,7 @@ DATADOG_AGENT_SIX_API int get_check(six_t *, const char *name, const char *init_
                                     six_pyobject_t **check, char **version);
 DATADOG_AGENT_SIX_API const char *run_check(six_t *, six_pyobject_t *check);
 DATADOG_AGENT_SIX_API void six_free(six_t *, void *ptr);
+DATADOG_AGENT_SIX_API void six_decref(six_t *, six_pyobject_t *);
 
 // C CONST API
 DATADOG_AGENT_SIX_API int is_initialized(six_t *);

--- a/include/six.h
+++ b/include/six.h
@@ -34,6 +34,7 @@ public:
     virtual const char *runCheck(SixPyObject *check) = 0;
     void clearError();
     void free(void *);
+    virtual void decref(SixPyObject *) = 0;
 
     // Public Const API
     virtual bool isInitialized() const = 0;

--- a/include/six.h
+++ b/include/six.h
@@ -33,6 +33,7 @@ public:
         = 0;
     virtual const char *runCheck(SixPyObject *check) = 0;
     void clearError();
+    void free(void *);
 
     // Public Const API
     virtual bool isInitialized() const = 0;

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -231,3 +231,7 @@ void clear_error(six_t *six) {
 void set_submit_metric_cb(six_t *six, cb_submit_metric_t cb) {
     AS_TYPE(Six, six)->setSubmitMetricCb(cb);
 }
+
+void six_free(six_t *six, void *ptr) {
+    AS_TYPE(Six, six)->free(ptr);
+}

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -235,3 +235,7 @@ void set_submit_metric_cb(six_t *six, cb_submit_metric_t cb) {
 void six_free(six_t *six, void *ptr) {
     AS_TYPE(Six, six)->free(ptr);
 }
+
+void six_decref(six_t *six, six_pyobject_t *obj) {
+    AS_TYPE(Six, six)->decref(AS_TYPE(SixPyObject, obj));
+}

--- a/six/six.cpp
+++ b/six/six.cpp
@@ -58,3 +58,9 @@ void Six::clearError() {
     _errorFlag = false;
     _error = "";
 }
+
+void Six::free(void *ptr) {
+    if (ptr != NULL) {
+        free(ptr);
+    }
+}

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -526,6 +526,10 @@ done:
     return ret;
 }
 
+void Three::decref(SixPyObject *obj) {
+    Py_XDECREF(reinterpret_cast<SixPyObject *>(obj));
+}
+
 void Three::setSubmitMetricCb(cb_submit_metric_t cb) {
     _set_submit_metric_cb(cb);
 }

--- a/three/three.h
+++ b/three/three.h
@@ -48,6 +48,7 @@ public:
     bool getCheck(const char *module, const char *init_config, const char *instances, SixPyObject *&check,
                   char *&version);
     const char *runCheck(SixPyObject *check);
+    void decref(SixPyObject *);
 
     // const API
     bool isInitialized() const;

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -469,3 +469,7 @@ done:
     Py_XDECREF(py_version);
     return ret;
 }
+
+void Two::decref(SixPyObject *obj) {
+    Py_XDECREF(reinterpret_cast<SixPyObject *>(obj));
+}

--- a/two/two.h
+++ b/two/two.h
@@ -31,6 +31,7 @@ public:
     bool getCheck(const char *module, const char *init_config, const char *instances, SixPyObject *&check,
                   char *&version);
     const char *runCheck(SixPyObject *check);
+    void decref(SixPyObject *);
 
     // const API
     bool isInitialized() const;


### PR DESCRIPTION
Agent can't cross DLL boundaries hence memory created on the Six side must be destroyed there as well. Expose `free` and `Py_XDECREF` like functions to do this.