### PR TITLE
[datadog_agent] get_config implementation

### DIFF
--- a/common/datadog_agent.h
+++ b/common/datadog_agent.h
@@ -20,6 +20,7 @@ void Py2_init_datadog_agent();
 #endif
 
 void _set_get_version_cb(cb_get_version_t);
+void _set_get_config_cb(cb_get_config_t);
 
 #ifdef __cplusplus
 }

--- a/common/sixstrings.c
+++ b/common/sixstrings.c
@@ -30,3 +30,28 @@ char *as_string(PyObject *object) {
 #endif
     return retval;
 }
+
+PyObject *from_json(const char *data) {
+    PyObject *retval = NULL;
+    PyObject *json = NULL;
+    PyObject *loads = NULL;
+
+    char module_name[] = "json";
+    json = PyImport_ImportModule(module_name);
+    if (json == NULL) {
+        goto done;
+    }
+
+    char func_name[] = "loads";
+    loads = PyObject_GetAttrString(json, func_name);
+    if (loads == NULL) {
+        goto done;
+    }
+
+    retval = PyObject_CallFunction(loads, "s", data);
+
+done:
+    Py_XDECREF(json);
+    Py_XDECREF(loads);
+    return retval;
+}

--- a/common/sixstrings.h
+++ b/common/sixstrings.h
@@ -7,5 +7,6 @@
 #include <Python.h>
 
 char *as_string(PyObject *);
+PyObject *from_json(const char *);
 
 #endif

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -48,6 +48,7 @@ DATADOG_AGENT_SIX_API void set_submit_event_cb(six_t *, cb_submit_event_t);
 
 // DATADOG_AGENT API
 DATADOG_AGENT_SIX_API void set_get_version_cb(six_t *, cb_get_version_t);
+DATADOG_AGENT_SIX_API void set_get_config_cb(six_t *, cb_get_config_t);
 
 #ifdef __cplusplus
 }

--- a/include/six.h
+++ b/include/six.h
@@ -51,6 +51,7 @@ public:
 
     // datadog_agent API
     virtual void setGetVersionCb(cb_get_version_t) = 0;
+    virtual void setGetConfigCb(cb_get_config_t) = 0;
 
 private:
     mutable std::string _error;

--- a/include/six_types.h
+++ b/include/six_types.h
@@ -71,6 +71,8 @@ typedef void (*cb_submit_event_t)(char *, event_t *);
 //
 // (string_to_be_filled)
 typedef void (*cb_get_version_t)(char **);
+// (key, string_to_be_filled)
+typedef void (*cb_get_config_t)(char *, char **);
 
 #ifdef __cplusplus
 }

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -259,3 +259,7 @@ void set_submit_event_cb(six_t *six, cb_submit_event_t cb) {
 void set_get_version_cb(six_t *six, cb_get_version_t cb) {
     AS_TYPE(Six, six)->setGetVersionCb(cb);
 }
+
+void set_get_config_cb(six_t *six, cb_get_config_t cb) {
+    AS_TYPE(Six, six)->setGetConfigCb(cb);
+}

--- a/test/datadog_agent/datadog_agent.go
+++ b/test/datadog_agent/datadog_agent.go
@@ -1,6 +1,7 @@
 package testdatadogagent
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -12,13 +13,21 @@ import (
 // #include <datadog_agent_six.h>
 //
 // extern void getVersion(char **);
+// extern void getConfig(char *, char **);
 //
 // static void initDatadogAgentTests(six_t *six) {
 //    set_get_version_cb(six, getVersion);
+//    set_get_config_cb(six, getConfig);
 // }
 import "C"
 
 var six *C.six_t
+
+type message struct {
+	Name string `json:"name"`
+	Body string `json:"body"`
+	Time int64  `json:"time"`
+}
 
 func setUp() error {
 	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
@@ -86,4 +95,12 @@ except Exception as e:
 //export getVersion
 func getVersion(in **C.char) {
 	*in = C.CString("1.2.3")
+}
+
+//export getConfig
+func getConfig(key *C.char, in **C.char) {
+	m := message{C.GoString(key), "Hello", 123456}
+	b, _ := json.Marshal(m)
+
+	*in = C.CString(string(b))
 }

--- a/test/datadog_agent/datadog_agent_test.go
+++ b/test/datadog_agent/datadog_agent_test.go
@@ -32,3 +32,18 @@ func TestGetVersion(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 }
+
+func TestGetConfig(t *testing.T) {
+	code := `
+	d = datadog_agent.get_config("foo")
+	sys.stderr.write("{}:{}:{}".format(d.get('name'), d.get('body'), d.get('time')))
+	sys.stderr.flush()
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "foo:Hello:123456" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+}

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -451,3 +451,7 @@ void Three::setSubmitEventCb(cb_submit_event_t cb) {
 void Three::setGetVersionCb(cb_get_version_t cb) {
     _set_get_version_cb(cb);
 }
+
+void Three::setGetConfigCb(cb_get_config_t cb) {
+    _set_get_config_cb(cb);
+}

--- a/three/three.h
+++ b/three/three.h
@@ -58,6 +58,7 @@ public:
 
     // datadog_agent
     void setGetVersionCb(cb_get_version_t);
+    void setGetConfigCb(cb_get_config_t);
 
 private:
     PyObject *_importFrom(const char *module, const char *name);

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -435,3 +435,7 @@ void Two::setSubmitEventCb(cb_submit_event_t cb) {
 void Two::setGetVersionCb(cb_get_version_t cb) {
     _set_get_version_cb(cb);
 }
+
+void Two::setGetConfigCb(cb_get_config_t cb) {
+    _set_get_config_cb(cb);
+}

--- a/two/two.h
+++ b/two/two.h
@@ -44,6 +44,7 @@ public:
 
     // datadog_agent
     void setGetVersionCb(cb_get_version_t);
+    void setGetConfigCb(cb_get_config_t);
 
 private:
     PyObject *_importFrom(const char *module, const char *name);


### PR DESCRIPTION
## Preamble

`datadog_agent.get_config('foo')` returns the value of the key `foo` in the configuration object from the Agent. The value is a Python object with a type dependent of the original type for the value in Go, for example: a `map` in go would return a `dict` in Python, a `slice` a `list` and so on.

## Implementation

Currently the Agent uses reflection to inspect the contents of a configuration value and the CPython API to perform conversion to a Python equivalent. Such a conversion wouldn't be possible in a Python-agnostic way so we use JSON to pass the data from Go to Python. The configuration value is loaded in the Agent, marshalled into JSON and passed as a `char*` to Six, where the string is decoded back to Python and passed to the caller. JSON usage is transparent to the caller, who would receive a Python object as returned from `json.loads`.

## Examples

This is how the Agent code would look like: https://github.com/DataDog/datadog-agent-six/pull/21/files#diff-1ea5fe10019b86af6c6ac186508d328aR101

This is to show how this is transparent from Python: https://github.com/DataDog/datadog-agent-six/pull/21/files#diff-2793a089ab02160ae06a4f20b051ec8eR39