### PR TITLE
Split the get_check method

### DIFF
--- a/common/datadog_agent.c
+++ b/common/datadog_agent.c
@@ -102,7 +102,9 @@ PyObject *get_version(PyObject *self, PyObject *args) {
  */
 PyObject *get_config(PyObject *self, PyObject *args) {
     // callback must be set
-    assert(cb_get_config != NULL);
+    if (cb_get_config == NULL) {
+        Py_RETURN_NONE;
+    }
 
     char *key;
     if (!PyArg_ParseTuple(args, "s", &key)) {

--- a/demo/main.c
+++ b/demo/main.c
@@ -89,6 +89,7 @@ int main(int argc, char *argv[]) {
 
     printf("Embedding Python version %s\n\n", get_py_version(six));
 
+    six_gilstate_t state = ensure_gil(six);
     // run a script from file
     char *code = read_file("./demo/main.py");
     run_simple_string(six, code);
@@ -158,6 +159,10 @@ int main(int argc, char *argv[]) {
     } else {
         printf("Error running the check, output:\n %s\n", result);
     }
+    release_gil(six, state);
+
+    printf("Destroying python\n");
+    destroy(six);
 
     return 0;
 }

--- a/demo/main.c
+++ b/demo/main.c
@@ -133,8 +133,8 @@ int main(int argc, char *argv[]) {
         printf("Successfully imported Directory integration.\n\n");
     }
     printf("Directory __file__: %s.\n", file);
-    free(version);
-    free(file);
+    six_free(six, version);
+    six_free(six, file);
 
     // load the Directory check if available
     six_pyobject_t *check;

--- a/demo/main.c
+++ b/demo/main.c
@@ -128,23 +128,29 @@ int main(int argc, char *argv[]) {
         return 1;
     }
     if (version != NULL) {
-        printf("Successfully imported Directory integration v%s.\n\n", version);
+        printf("Successfully imported Directory integration v%s.\n", version);
     } else {
-        printf("Successfully imported Directory integration.\n\n");
+        printf("Successfully imported Directory integration.\n");
     }
-    printf("Directory __file__: %s.\n", file);
+    printf("Directory __file__: %s.\n\n", file);
     six_free(six, version);
     six_free(six, file);
 
     // load the Directory check if available
     six_pyobject_t *check;
 
-    ok = get_check(six, py_class, "", "{directory: \"/\"}", "", "directoryID", &check);
+    ok = get_check(six, py_class, "", "{directory: \"/\"}", "directoryID", "directory", &check);
     if (!ok) {
-        if (has_error(six)) {
-            printf("error loading check: %s\n", get_error(six));
+        printf("warning: could not get_check with new api: trying with deprecated API\n");
+        // clean error
+        get_error(six);
+
+        if (!get_check_deprecated(six, py_class, "", "{directory: \"/\"}", "directoryID", "directory", "", &check)) {
+            if (has_error(six)) {
+                printf("error loading check: %s\n", get_error(six));
+            }
+            return 1;
         }
-        return 1;
     }
 
     const char *result = run_check(six, check);

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -27,8 +27,11 @@ DATADOG_AGENT_SIX_API int add_python_path(six_t *, const char *path);
 DATADOG_AGENT_SIX_API six_gilstate_t ensure_gil(six_t *);
 DATADOG_AGENT_SIX_API void clear_error(six_t *);
 DATADOG_AGENT_SIX_API void release_gil(six_t *, six_gilstate_t);
-DATADOG_AGENT_SIX_API int get_check(six_t *, const char *name, const char *init_config, const char *instances,
-                                    six_pyobject_t **check, char **version);
+DATADOG_AGENT_SIX_API int get_class(six_t *six, const char *name, six_pyobject_t **py_module,
+                                    six_pyobject_t **py_class);
+DATADOG_AGENT_SIX_API int get_attr_string(six_t *six, six_pyobject_t *py_class, const char *attr_name, char **value);
+DATADOG_AGENT_SIX_API int get_check(six_t *six, six_pyobject_t *py_class, const char *init_config, const char *instance,
+                                    const char *agent_config, const char *check_id, six_pyobject_t **check);
 DATADOG_AGENT_SIX_API const char *run_check(six_t *, six_pyobject_t *check);
 DATADOG_AGENT_SIX_API void six_free(six_t *, void *ptr);
 DATADOG_AGENT_SIX_API void six_decref(six_t *, six_pyobject_t *);

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -35,6 +35,7 @@ DATADOG_AGENT_SIX_API int get_check(six_t *six, six_pyobject_t *py_class, const 
 DATADOG_AGENT_SIX_API const char *run_check(six_t *, six_pyobject_t *check);
 DATADOG_AGENT_SIX_API void six_free(six_t *, void *ptr);
 DATADOG_AGENT_SIX_API void six_decref(six_t *, six_pyobject_t *);
+DATADOG_AGENT_SIX_API void six_incref(six_t *, six_pyobject_t *);
 
 // CONST API
 DATADOG_AGENT_SIX_API int is_initialized(six_t *);

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -24,8 +24,8 @@ DATADOG_AGENT_SIX_API six_t *make3();
 DATADOG_AGENT_SIX_API void destroy(six_t *);
 DATADOG_AGENT_SIX_API int init(six_t *, char *);
 DATADOG_AGENT_SIX_API int add_python_path(six_t *, const char *path);
-DATADOG_AGENT_SIX_API six_gilstate_t ensure_gil(six_t *);
 DATADOG_AGENT_SIX_API void clear_error(six_t *);
+DATADOG_AGENT_SIX_API six_gilstate_t ensure_gil(six_t *);
 DATADOG_AGENT_SIX_API void release_gil(six_t *, six_gilstate_t);
 DATADOG_AGENT_SIX_API int get_class(six_t *six, const char *name, six_pyobject_t **py_module,
                                     six_pyobject_t **py_class);

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -31,7 +31,10 @@ DATADOG_AGENT_SIX_API int get_class(six_t *six, const char *name, six_pyobject_t
                                     six_pyobject_t **py_class);
 DATADOG_AGENT_SIX_API int get_attr_string(six_t *six, six_pyobject_t *py_class, const char *attr_name, char **value);
 DATADOG_AGENT_SIX_API int get_check(six_t *six, six_pyobject_t *py_class, const char *init_config, const char *instance,
-                                    const char *agent_config, const char *check_id, six_pyobject_t **check);
+                                    const char *check_id, const char *check_name, six_pyobject_t **check);
+DATADOG_AGENT_SIX_API int get_check_deprecated(six_t *six, six_pyobject_t *py_class, const char *init_config,
+                                               const char *instance, const char *check_id, const char *check_name,
+                                               const char *agent_config, six_pyobject_t **check);
 DATADOG_AGENT_SIX_API const char *run_check(six_t *, six_pyobject_t *check);
 DATADOG_AGENT_SIX_API void six_free(six_t *, void *ptr);
 DATADOG_AGENT_SIX_API void six_decref(six_t *, six_pyobject_t *);

--- a/include/six.h
+++ b/include/six.h
@@ -26,8 +26,11 @@ public:
     virtual bool addPythonPath(const char *path) = 0;
     virtual six_gilstate_t GILEnsure() = 0;
     virtual void GILRelease(six_gilstate_t) = 0;
-    virtual bool getCheck(const char *name, const char *init_config, const char *instances, SixPyObject *&check,
-                          char *&version)
+
+    virtual bool getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyClass) = 0;
+    virtual bool getAttrString(SixPyObject *obj, const char *attributeName, char *&value) const = 0;
+    virtual bool getCheck(SixPyObject *py_class, const char *init_config, const char *instance,
+                          const char *agent_config, const char *check_id, SixPyObject *&check)
         = 0;
     virtual const char *runCheck(SixPyObject *check) = 0;
     void clearError();

--- a/include/six.h
+++ b/include/six.h
@@ -29,8 +29,9 @@ public:
 
     virtual bool getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyClass) = 0;
     virtual bool getAttrString(SixPyObject *obj, const char *attributeName, char *&value) const = 0;
-    virtual bool getCheck(SixPyObject *py_class, const char *init_config, const char *instance,
-                          const char *agent_config, const char *check_id, SixPyObject *&check)
+    virtual bool getCheck(SixPyObject *py_class, const char *init_config_str, const char *instance_str,
+                          const char *check_id_str, const char *check_name, const char *agent_config_str,
+                          SixPyObject *&check)
         = 0;
 
     virtual const char *runCheck(SixPyObject *check) = 0;

--- a/include/six.h
+++ b/include/six.h
@@ -32,10 +32,12 @@ public:
     virtual bool getCheck(SixPyObject *py_class, const char *init_config, const char *instance,
                           const char *agent_config, const char *check_id, SixPyObject *&check)
         = 0;
+
     virtual const char *runCheck(SixPyObject *check) = 0;
     void clearError();
     void free(void *);
     virtual void decref(SixPyObject *) = 0;
+    virtual void incref(SixPyObject *) = 0;
 
     // Public Const API
     virtual bool isInitialized() const = 0;

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -208,10 +208,19 @@ int get_attr_string(six_t *six, six_pyobject_t *py_class, const char *attr_name,
     return AS_TYPE(Six, six)->getAttrString(AS_TYPE(SixPyObject, py_class), attr_name, *value);
 }
 
-int get_check(six_t *six, six_pyobject_t *py_class, const char *init_config, const char *instance,
-              const char *agent_config, const char *check_id, six_pyobject_t **check) {
-    return AS_TYPE(Six, six)->getCheck(AS_TYPE(SixPyObject, py_class), init_config, instance, agent_config, check_id,
-                                       *AS_PTYPE(SixPyObject, check))
+int get_check(six_t *six, six_pyobject_t *py_class, const char *init_config, const char *instance, const char *check_id,
+              const char *check_name, six_pyobject_t **check) {
+    return AS_TYPE(Six, six)->getCheck(AS_TYPE(SixPyObject, py_class), init_config, instance, check_id, check_name,
+                                       NULL, *AS_PTYPE(SixPyObject, check))
+        ? 1
+        : 0;
+}
+
+int get_check_deprecated(six_t *six, six_pyobject_t *py_class, const char *init_config, const char *instance,
+                         const char *agent_config, const char *check_id, const char *check_name,
+                         six_pyobject_t **check) {
+    return AS_TYPE(Six, six)->getCheck(AS_TYPE(SixPyObject, py_class), init_config, instance, check_id, check_name,
+                                       agent_config, *AS_PTYPE(SixPyObject, check))
         ? 1
         : 0;
 }

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -248,6 +248,10 @@ void six_decref(six_t *six, six_pyobject_t *obj) {
     AS_TYPE(Six, six)->decref(AS_TYPE(SixPyObject, obj));
 }
 
+void six_incref(six_t *six, six_pyobject_t *obj) {
+    AS_TYPE(Six, six)->incref(AS_TYPE(SixPyObject, obj));
+}
+
 /*
  * aggregator API
  */

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -199,9 +199,21 @@ void release_gil(six_t *six, six_gilstate_t state) {
     AS_TYPE(Six, six)->GILRelease(state);
 }
 
-int get_check(six_t *six, const char *name, const char *init_config, const char *instances, six_pyobject_t **check,
-              char **version) {
-    return AS_TYPE(Six, six)->getCheck(name, init_config, instances, *AS_PTYPE(SixPyObject, check), *version) ? 1 : 0;
+int get_class(six_t *six, const char *name, six_pyobject_t **py_module, six_pyobject_t **py_class) {
+    return AS_TYPE(Six, six)->getClass(name, *AS_PTYPE(SixPyObject, py_module), *AS_PTYPE(SixPyObject, py_class)) ? 1
+                                                                                                                  : 0;
+}
+
+int get_attr_string(six_t *six, six_pyobject_t *py_class, const char *attr_name, char **value) {
+    return AS_TYPE(Six, six)->getAttrString(AS_TYPE(SixPyObject, py_class), attr_name, *value);
+}
+
+int get_check(six_t *six, six_pyobject_t *py_class, const char *init_config, const char *instance,
+              const char *agent_config, const char *check_id, six_pyobject_t **check) {
+    return AS_TYPE(Six, six)->getCheck(AS_TYPE(SixPyObject, py_class), init_config, instance, agent_config, check_id,
+                                       *AS_PTYPE(SixPyObject, check))
+        ? 1
+        : 0;
 }
 
 const char *run_check(six_t *six, six_pyobject_t *check) {

--- a/six/six.cpp
+++ b/six/six.cpp
@@ -36,6 +36,6 @@ void Six::clearError() {
 
 void Six::free(void *ptr) {
     if (ptr != NULL) {
-        free(ptr);
+        ::free(ptr);
     }
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,10 +7,10 @@ PKGS = \
 
 all: test
 
+# due to the nature of the tests, disable caching and parallelism with -count=1 and -p=1 respectively
 test:
-	# due to the nature of the tests, disable caching and parallelism
 	@echo Run Python2 testsuite...
-	@DYLD_LIBRARY_PATH=$(LIB_PATH) LD_LIBRARY_PATH=$(LIB_PATH) TEST_TWO= go test -count=1 -p=1 $(PKGS)
+	@DYLD_LIBRARY_PATH=$(LIB_PATH) LD_LIBRARY_PATH=$(LIB_PATH) TESTING_TWO= go test -count=1 -p=1 $(PKGS)
 	@echo
 	@echo Run Python3 testsuite...
 	@DYLD_LIBRARY_PATH=$(LIB_PATH) LD_LIBRARY_PATH=$(LIB_PATH) go test -count=1 -p=1 $(PKGS)

--- a/test/aggregator/aggregator.go
+++ b/test/aggregator/aggregator.go
@@ -85,12 +85,8 @@ func setUp() error {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
 
+	C.ensure_gil(six)
 	return nil
-}
-
-func tearDown() {
-	C.destroy(six)
-	six = nil
 }
 
 func run(call string) (string, error) {
@@ -98,10 +94,12 @@ func run(call string) (string, error) {
 
 	code := C.CString(fmt.Sprintf(`
 try:
+	import sys
 	import aggregator
 	%s
 except Exception as e:
-	print(e, flush=True)
+	sys.stderr.write("{}\n".format(e))
+	sys.stderr.flush()
 `, call))
 
 	var (

--- a/test/aggregator/aggregator_test.go
+++ b/test/aggregator/aggregator_test.go
@@ -13,10 +13,7 @@ func TestMain(m *testing.M) {
 		os.Exit(-1)
 	}
 
-	ret := m.Run()
-
-	tearDown()
-	os.Exit(ret)
+	os.Exit(m.Run())
 }
 
 func TestSubmitMetric(t *testing.T) {

--- a/test/datadog_agent/datadog_agent.go
+++ b/test/datadog_agent/datadog_agent.go
@@ -59,12 +59,8 @@ func setUp() error {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
 
+	C.ensure_gil(six)
 	return nil
-}
-
-func tearDown() {
-	C.destroy(six)
-	six = nil
 }
 
 func run(call string) (string, error) {

--- a/test/datadog_agent/datadog_agent_test.go
+++ b/test/datadog_agent/datadog_agent_test.go
@@ -48,14 +48,14 @@ func TestGetConfig(t *testing.T) {
 func TestHeaders(t *testing.T) {
 	code := `
 	d = datadog_agent.headers(http_host="myhost", ignore_me="snafu")
-	sys.stderr.write(",".join(d.keys()))
+	sys.stderr.write(",".join(sorted(d.keys())))
 	sys.stderr.flush()
 	`
 	out, err := run(code)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "Accept,Content-Type,User-Agent,Host" {
+	if out != "Accept,Content-Type,Host,User-Agent" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 }

--- a/test/datadog_agent/datadog_agent_test.go
+++ b/test/datadog_agent/datadog_agent_test.go
@@ -13,10 +13,7 @@ func TestMain(m *testing.M) {
 		os.Exit(-1)
 	}
 
-	ret := m.Run()
-
-	tearDown()
-	os.Exit(ret)
+	os.Exit(m.Run())
 }
 
 func TestGetVersion(t *testing.T) {

--- a/test/init/init.go
+++ b/test/init/init.go
@@ -33,11 +33,6 @@ func runInit() error {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
 
-	ok := C.init(six, nil)
-	if ok != 1 {
-		return fmt.Errorf("`init` failed")
-	}
-
 	if C.is_initialized(six) != 1 {
 		return fmt.Errorf("Six not initialized")
 	}

--- a/test/python/datadog_checks/checks/__init__.py
+++ b/test/python/datadog_checks/checks/__init__.py
@@ -1,0 +1,3 @@
+# replicate the backward compat redirection we have in integrations-core
+from ..base.checks import *
+

--- a/test/six/six.go
+++ b/test/six/six.go
@@ -96,7 +96,7 @@ func getFakeCheck() (string, error) {
 	}
 
 	// check instance
-	ret = C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString(""), C.CString("checkID"), &check)
+	ret = C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString("checkID"), C.CString("fake_check"), &check)
 	if ret != 1 || check == nil {
 		return "", fmt.Errorf(C.GoString(C.get_error(six)))
 	}
@@ -112,7 +112,7 @@ func runFakeCheck() (string, error) {
 
 	C.get_class(six, C.CString("datadog_checks.directory"), &module, &class)
 	C.get_attr_string(six, module, C.CString("__version__"), &version)
-	C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString(""), C.CString("checkID"), &check)
+	C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString("checkID"), C.CString("fake_check"), &check)
 
 	return C.GoString(C.run_check(six, check)), nil
 }

--- a/test/six/six.go
+++ b/test/six/six.go
@@ -35,13 +35,8 @@ func setUp() error {
 	if ok != 1 {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
-
+	C.ensure_gil(six)
 	return nil
-}
-
-func tearDown() {
-	C.destroy(six)
-	six = nil
 }
 
 func getVersion() string {
@@ -70,19 +65,21 @@ func runString(code string) (string, error) {
 
 func getError() string {
 	// following is supposed to raise an error
-	C.get_check(six, C.CString("foo"), C.CString(""), C.CString("[{foo: \"/\"}]"), nil, nil)
+	C.get_class(six, C.CString("foo"), nil, nil)
 	return C.GoString(C.get_error(six))
 }
 
 func hasError() bool {
 	// following is supposed to raise an error
-	C.get_check(six, C.CString("foo"), C.CString(""), C.CString("[{foo: \"/\"}]"), nil, nil)
+	C.get_class(six, C.CString("foo"), nil, nil)
 	ret := C.has_error(six) == 1
 	C.clear_error(six)
 	return ret
 }
 
 func getFakeCheck() (string, error) {
+	var module *C.six_pyobject_t
+	var class *C.six_pyobject_t
 	var check *C.six_pyobject_t
 	var version *C.char
 
@@ -98,7 +95,9 @@ func getFakeCheck() (string, error) {
 		return "", fmt.Errorf(C.GoString(C.get_error(six)))
 	}
 
-	if ret != 1 || check == nil || version == nil {
+	// check instance
+	ret = C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString(""), C.CString("checkID"), &check)
+	if ret != 1 || check == nil {
 		return "", fmt.Errorf(C.GoString(C.get_error(six)))
 	}
 
@@ -106,6 +105,8 @@ func getFakeCheck() (string, error) {
 }
 
 func runFakeCheck() (string, error) {
+	var module *C.six_pyobject_t
+	var class *C.six_pyobject_t
 	var check *C.six_pyobject_t
 	var version *C.char
 

--- a/test/six/six.go
+++ b/test/six/six.go
@@ -86,7 +86,17 @@ func getFakeCheck() (string, error) {
 	var check *C.six_pyobject_t
 	var version *C.char
 
-	ret := C.get_check(six, C.CString("fake_check"), C.CString(""), C.CString("[{fake_check: \"/\"}]"), &check, &version)
+	// class
+	ret := C.get_class(six, C.CString("fake_check"), &module, &class)
+	if ret != 1 || module == nil || class == nil {
+		return "", fmt.Errorf(C.GoString(C.get_error(six)))
+	}
+
+	// version
+	ret = C.get_attr_string(six, module, C.CString("__version__"), &version)
+	if ret != 1 || version == nil {
+		return "", fmt.Errorf(C.GoString(C.get_error(six)))
+	}
 
 	if ret != 1 || check == nil || version == nil {
 		return "", fmt.Errorf(C.GoString(C.get_error(six)))
@@ -99,10 +109,9 @@ func runFakeCheck() (string, error) {
 	var check *C.six_pyobject_t
 	var version *C.char
 
-	ret := C.get_check(six, C.CString("fake_check"), C.CString(""), C.CString("[{fake_check: \"/\"}]"), &check, &version)
-	if ret != 1 {
-		return "", fmt.Errorf(C.GoString(C.get_error(six)))
-	}
+	C.get_class(six, C.CString("datadog_checks.directory"), &module, &class)
+	C.get_attr_string(six, module, C.CString("__version__"), &version)
+	C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString(""), C.CString("checkID"), &check)
 
 	return C.GoString(C.run_check(six, check)), nil
 }

--- a/test/six/six_test.go
+++ b/test/six/six_test.go
@@ -14,34 +14,40 @@ func TestMain(m *testing.M) {
 		os.Exit(-1)
 	}
 
-	ret := m.Run()
-
-	tearDown()
-	os.Exit(ret)
+	os.Exit(m.Run())
 }
 
 func TestGetVersion(t *testing.T) {
 	ver := getVersion()
-	if !strings.HasPrefix(ver, "3.") {
-		t.Errorf("Version doesn't start with `3.`: %s", ver)
+	prefix := "3."
+	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
+		prefix = "2.7."
+	}
+
+	if !strings.HasPrefix(ver, prefix) {
+		t.Errorf("Version doesn't start with `%s`: %s", prefix, ver)
 	}
 }
 
 func TestRunSimpleString(t *testing.T) {
-	output, err := runString("print('Hello, World!', flush=True)\n")
+	output, err := runString("import sys; sys.stderr.write('Hello, World!'); sys.stderr.flush()")
 
 	if err != nil {
 		t.Fatalf("`run_simple_string` error: %v", err)
 	}
 
-	if output != "Hello, World!\n" {
+	if output != "Hello, World!" {
 		t.Errorf("Unexpected printed value: '%s'", output)
 	}
 }
 
 func TestGetError(t *testing.T) {
 	errorStr := getError()
-	if errorStr != "unable to import module 'foo': No module named 'foo'" {
+	expected := "unable to import module 'foo': No module named 'foo'"
+	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
+		expected = "unable to import module 'foo': No module named foo"
+	}
+	if errorStr != expected {
 		t.Fatalf("Wrong error string returned: %s", errorStr)
 	}
 }

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -21,6 +21,7 @@ extern "C" DATADOG_AGENT_SIX_API void destroy(Six *p) {
 }
 
 Three::~Three() {
+    PyEval_RestoreThread(_threadState);
     if (_pythonHome) {
         PyMem_RawFree((void *)_pythonHome);
     }
@@ -57,8 +58,10 @@ bool Three::init(const char *pythonHome) {
     }
 
     // load the base class
-    _baseClass = _importFrom("datadog_checks.base.checks", "AgentCheck");
+    _baseClass = _importFrom("datadog_checks.checks", "AgentCheck");
 
+    // save tread state and release the GIL
+    _threadState = PyEval_SaveThread();
     return _baseClass != NULL;
 }
 

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -472,6 +472,10 @@ void Three::decref(SixPyObject *obj) {
     Py_XDECREF(reinterpret_cast<PyObject *>(obj));
 }
 
+void Three::incref(SixPyObject *obj) {
+    Py_XINCREF(reinterpret_cast<PyObject *>(obj));
+}
+
 void Three::setSubmitMetricCb(cb_submit_metric_t cb) {
     _set_submit_metric_cb(cb);
 }

--- a/three/three.h
+++ b/three/three.h
@@ -42,7 +42,7 @@ public:
     bool getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyClass);
     bool getAttrString(SixPyObject *obj, const char *attributeName, char *&value) const;
     bool getCheck(SixPyObject *py_class, const char *init_config_str, const char *instance_str,
-                  const char *agent_config_str, const char *check_id, SixPyObject *&check);
+                  const char *check_id_str, const char *check_name, const char *agent_config_str, SixPyObject *&check);
 
     const char *runCheck(SixPyObject *check);
     void decref(SixPyObject *obj);

--- a/three/three.h
+++ b/three/three.h
@@ -38,8 +38,12 @@ public:
     bool addPythonPath(const char *path);
     six_gilstate_t GILEnsure();
     void GILRelease(six_gilstate_t);
-    bool getCheck(const char *module, const char *init_config, const char *instances, SixPyObject *&check,
-                  char *&version);
+
+    bool getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyClass);
+    bool getAttrString(SixPyObject *obj, const char *attributeName, char *&value) const;
+    bool getCheck(SixPyObject *py_class, const char *init_config_str, const char *instance_str,
+                  const char *agent_config_str, const char *check_id, SixPyObject *&check);
+
     const char *runCheck(SixPyObject *check);
     void decref(SixPyObject *);
 
@@ -68,7 +72,6 @@ private:
     PyObject *_importFrom(const char *module, const char *name);
     PyObject *_findSubclassOf(PyObject *base, PyObject *module);
     std::string _fetchPythonError() const;
-    char *_getCheckVersion(PyObject *module) const;
 
     typedef std::vector<std::string> PyPaths;
 

--- a/three/three.h
+++ b/three/three.h
@@ -45,7 +45,8 @@ public:
                   const char *agent_config_str, const char *check_id, SixPyObject *&check);
 
     const char *runCheck(SixPyObject *check);
-    void decref(SixPyObject *);
+    void decref(SixPyObject *obj);
+    void incref(SixPyObject *obj);
 
     // const API
     bool isInitialized() const;

--- a/three/three.h
+++ b/three/three.h
@@ -78,6 +78,7 @@ private:
     wchar_t *_pythonHome;
     PyObject *_baseClass;
     PyPaths _pythonPaths;
+    PyThreadState *_threadState;
 };
 
 #endif

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -134,39 +134,45 @@ done:
     return reinterpret_cast<SixPyObject *>(klass);
 }
 
-bool Two::getCheck(const char *module, const char *init_config_str, const char *instances_str, SixPyObject *&pycheck,
-                   char *&version) {
+bool Two::getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyClass) {
     PyObject *obj_module = NULL;
-    PyObject *klass = NULL;
-    PyObject *init_config = NULL;
-    PyObject *instances = NULL;
-    PyObject *check = NULL;
-    PyObject *args = NULL;
-    PyObject *kwargs = NULL;
+    PyObject *obj_class = NULL;
 
-    char load_config[] = "load_config";
-    char format[] = "(s)"; // use parentheses to force Tuple creation
-
-    // try to import python module containing the check
     obj_module = PyImport_ImportModule(module);
     if (obj_module == NULL) {
         std::ostringstream err;
         err << "unable to import module '" << module << "': " + _fetchPythonError();
         setError(err.str());
-        goto done;
+        return false;
     }
 
-    // find a subclass of the base check
-    klass = _findSubclassOf(_baseClass, obj_module);
-    if (klass == NULL) {
+    obj_class = _findSubclassOf(_baseClass, obj_module);
+    if (obj_class == NULL) {
         std::ostringstream err;
         err << "unable to find a subclass of the base check in module '" << module << "': " << _fetchPythonError();
         setError(err.str());
-        goto done;
+        Py_XDECREF(obj_module);
+        return false;
     }
 
-    // try to get Check version
-    version = _getCheckVersion(obj_module);
+    pyModule = reinterpret_cast<SixPyObject *>(obj_module);
+    pyClass = reinterpret_cast<SixPyObject *>(obj_class);
+    return true;
+}
+
+bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const char *instance_str,
+                   const char *agent_config, const char *check_id, SixPyObject *&pycheck) {
+    PyObject *klass = reinterpret_cast<PyObject *>(py_class);
+    PyObject *init_config = NULL;
+    PyObject *instance = NULL;
+    PyObject *instances = NULL;
+    PyObject *check = NULL;
+    PyObject *args = NULL;
+    PyObject *kwargs = NULL;
+    PyObject *py_check_id = NULL;
+
+    char load_config[] = "load_config";
+    char format[] = "(s)"; // use parentheses to force Tuple creation
 
     // call `AgentCheck.load_config(init_config)`
     init_config = PyObject_CallMethod(klass, load_config, format, init_config_str);
@@ -175,10 +181,16 @@ bool Two::getCheck(const char *module, const char *init_config_str, const char *
         goto done;
     }
 
-    // call `AgentCheck.load_config(instances)`
-    instances = PyObject_CallMethod(klass, load_config, format, instances_str);
-    if (instances == NULL) {
-        setError("error parsing instances: " + _fetchPythonError());
+    // call `AgentCheck.load_config(instance)`
+    instance = PyObject_CallMethod(klass, load_config, format, instance_str);
+    if (instance == NULL) {
+        setError("error parsing instance: " + _fetchPythonError());
+        goto done;
+    }
+
+    instances = PyTuple_New(1);
+    if (PyTuple_SetItem(instances, 0, instance) != 0) {
+        setError("Could not create Tuple for instances: " + _fetchPythonError());
         goto done;
     }
 
@@ -195,11 +207,29 @@ bool Two::getCheck(const char *module, const char *init_config_str, const char *
         goto done;
     }
 
+    if (check_id != NULL && strlen(check_id) != 0) {
+        py_check_id = PyString_FromString(check_id);
+        if (py_check_id == NULL) {
+            std::ostringstream err;
+            err << "error could not set check_id: " << check_id;
+            setError(err.str());
+            Py_XDECREF(check);
+            check = NULL;
+            goto done;
+        }
+
+        if (PyObject_SetAttrString(check, "check_id", py_check_id) != 0) {
+            setError("error could not set 'check_id' attr: " + _fetchPythonError());
+            Py_XDECREF(check);
+            check = NULL;
+            goto done;
+        }
+    }
+
 done:
-    Py_XDECREF(obj_module);
-    Py_XDECREF(klass);
+    Py_XDECREF(py_check_id);
     Py_XDECREF(init_config);
-    Py_XDECREF(instances);
+    Py_XDECREF(instance);
     Py_XDECREF(args);
     Py_XDECREF(kwargs);
 
@@ -287,6 +317,7 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module) {
     }
 
     setError("cannot find a subclass");
+    klass = NULL;
 
 done:
     Py_XDECREF(dir);
@@ -392,32 +423,32 @@ std::string Two::_fetchPythonError() {
     return ret_val;
 }
 
-char *Two::_getCheckVersion(PyObject *module) const {
-    if (module == NULL) {
-        return NULL;
+bool Two::getAttrString(SixPyObject *obj, const char *attributeName, char *&value) const {
+    if (obj == NULL) {
+        return false;
     }
 
-    char *ret = NULL;
-    PyObject *py_version = NULL;
-    char version_field[] = "__version__";
+    bool res = false;
+    PyObject *py_attr = NULL;
+    PyObject *py_obj = reinterpret_cast<PyObject *>(obj);
 
-    // try getting module.__version__
-    py_version = PyObject_GetAttrString(module, version_field);
-    if (py_version != NULL && PyString_Check(py_version)) {
-        ret = _strdup(PyString_AS_STRING(py_version));
-        goto done;
+    py_attr = PyObject_GetAttrString(py_obj, attributeName);
+    if (py_attr != NULL && PyString_Check(py_attr)) {
+        value = _strdup(PyString_AS_STRING(py_attr));
+        res = true;
+    } else if (py_attr != NULL && !PyString_Check(py_attr)) {
+        setError("error attribute " + std::string(attributeName) + " is has a different type than string");
+        PyErr_Clear();
     } else {
-        // we expect __version__ might not be there, don't clutter the error stream
         PyErr_Clear();
     }
 
-done:
-    Py_XDECREF(py_version);
-    return ret;
+    Py_XDECREF(py_attr);
+    return res;
 }
 
 void Two::decref(SixPyObject *obj) {
-    Py_XDECREF(reinterpret_cast<SixPyObject *>(obj));
+    Py_XDECREF(reinterpret_cast<PyObject *>(obj));
 }
 
 void Two::setSubmitMetricCb(cb_submit_metric_t cb) {

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -10,6 +10,7 @@
 #include <datadog_agent.h>
 
 #include <algorithm>
+#include <iostream>
 #include <sstream>
 
 extern "C" DATADOG_AGENT_SIX_API Six *create() {
@@ -33,13 +34,13 @@ bool Two::init(const char *pythonHome) {
     Py_SetPythonHome(const_cast<char *>(_pythonHome));
     Py_Initialize();
 
-    // init custom builtins
-    Py2_init_aggregator();
-    Py2_init_datadog_agent();
-
     // In recent versions of Python3 this is called from Py_Initialize already,
     // for Python2 it has to be explicit.
     PyEval_InitThreads();
+
+    // init custom builtins
+    Py2_init_aggregator();
+    Py2_init_datadog_agent();
 
     // Set PYTHONPATH
     if (_pythonPaths.size()) {

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -166,15 +166,18 @@ bool Two::getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyC
 }
 
 bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const char *instance_str,
-                   const char *agent_config, const char *check_id, SixPyObject *&pycheck) {
+                   const char *check_id_str, const char *check_name, const char *agent_config_str,
+                   SixPyObject *&check) {
     PyObject *klass = reinterpret_cast<PyObject *>(py_class);
+    PyObject *agent_config = NULL;
     PyObject *init_config = NULL;
     PyObject *instance = NULL;
     PyObject *instances = NULL;
-    PyObject *check = NULL;
+    PyObject *py_check = NULL;
     PyObject *args = NULL;
     PyObject *kwargs = NULL;
-    PyObject *py_check_id = NULL;
+    PyObject *check_id = NULL;
+    PyObject *name = NULL;
 
     char load_config[] = "load_config";
     char format[] = "(s)"; // use parentheses to force Tuple creation
@@ -202,47 +205,61 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
     // create `args` and `kwargs` to invoke `AgentCheck` constructor
     args = PyTuple_New(0);
     kwargs = PyDict_New();
+    name = PyString_FromString(check_name);
+    PyDict_SetItemString(kwargs, "name", name);
     PyDict_SetItemString(kwargs, "init_config", init_config);
     PyDict_SetItemString(kwargs, "instances", instances);
 
-    // call `AgentCheck` constructor
-    check = PyObject_Call(klass, args, kwargs);
-    if (check == NULL) {
-        setError("error creating check instance: " + _fetchPythonError());
-        goto done;
-    }
-
-    if (check_id != NULL && strlen(check_id) != 0) {
-        py_check_id = PyString_FromString(check_id);
-        if (py_check_id == NULL) {
-            std::ostringstream err;
-            err << "error could not set check_id: " << check_id;
-            setError(err.str());
-            Py_XDECREF(check);
-            check = NULL;
+    if (agent_config_str != NULL) {
+        agent_config = PyObject_CallMethod(klass, load_config, format, agent_config_str);
+        if (agent_config == NULL) {
+            setError("error parsing agent_config: " + _fetchPythonError());
             goto done;
         }
 
-        if (PyObject_SetAttrString(check, "check_id", py_check_id) != 0) {
+        PyDict_SetItemString(kwargs, "agentConfig", agent_config);
+    }
+
+    // call `AgentCheck` constructor
+    py_check = PyObject_Call(klass, args, kwargs);
+    if (py_check == NULL) {
+        setError(_fetchPythonError());
+        goto done;
+    }
+
+    if (check_id_str != NULL && strlen(check_id_str) != 0) {
+        check_id = PyString_FromString(check_id_str);
+        if (check_id == NULL) {
+            std::ostringstream err;
+            err << "error could not set check_id: " << check_id_str;
+            setError(err.str());
+            Py_XDECREF(py_check);
+            py_check = NULL;
+            goto done;
+        }
+
+        if (PyObject_SetAttrString(py_check, "check_id", check_id) != 0) {
             setError("error could not set 'check_id' attr: " + _fetchPythonError());
-            Py_XDECREF(check);
-            check = NULL;
+            Py_XDECREF(py_check);
+            py_check = NULL;
             goto done;
         }
     }
 
 done:
-    Py_XDECREF(py_check_id);
+    Py_XDECREF(name);
+    Py_XDECREF(check_id);
     Py_XDECREF(init_config);
     Py_XDECREF(instance);
+    Py_XDECREF(agent_config);
     Py_XDECREF(args);
     Py_XDECREF(kwargs);
 
-    if (check == NULL) {
+    if (py_check == NULL) {
         return false;
     }
 
-    pycheck = reinterpret_cast<SixPyObject *>(check);
+    check = reinterpret_cast<SixPyObject *>(py_check);
     return true;
 }
 

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -455,6 +455,10 @@ void Two::decref(SixPyObject *obj) {
     Py_XDECREF(reinterpret_cast<PyObject *>(obj));
 }
 
+void Two::incref(SixPyObject *obj) {
+    Py_XINCREF(reinterpret_cast<SixPyObject *>(obj));
+}
+
 void Two::setSubmitMetricCb(cb_submit_metric_t cb) {
     _set_submit_metric_cb(cb);
 }

--- a/two/two.h
+++ b/two/two.h
@@ -24,8 +24,12 @@ public:
     six_gilstate_t GILEnsure();
     void GILRelease(six_gilstate_t);
     SixPyObject *getCheckClass(const char *module);
-    bool getCheck(const char *module, const char *init_config, const char *instances, SixPyObject *&check,
-                  char *&version);
+
+    bool getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyClass);
+    bool getAttrString(SixPyObject *obj, const char *attributeName, char *&value) const;
+    bool getCheck(SixPyObject *py_class, const char *init_config, const char *instance, const char *agent_config,
+                  const char *check_id, SixPyObject *&check);
+
     const char *runCheck(SixPyObject *check);
     void decref(SixPyObject *);
 
@@ -55,7 +59,6 @@ private:
     PyObject *_findSubclassOf(PyObject *base, PyObject *moduleName);
     PyObject *_getClass(const char *module, const char *base);
     std::string _fetchPythonError();
-    char *_getCheckVersion(PyObject *module) const;
 
     typedef std::vector<std::string> PyPaths;
 

--- a/two/two.h
+++ b/two/two.h
@@ -27,8 +27,8 @@ public:
 
     bool getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyClass);
     bool getAttrString(SixPyObject *obj, const char *attributeName, char *&value) const;
-    bool getCheck(SixPyObject *py_class, const char *init_config, const char *instance, const char *agent_config,
-                  const char *check_id, SixPyObject *&check);
+    bool getCheck(SixPyObject *py_class, const char *init_config_str, const char *instance_str,
+                  const char *check_id_str, const char *check_name, const char *agent_config_str, SixPyObject *&check);
 
     const char *runCheck(SixPyObject *check);
     void decref(SixPyObject *obj);

--- a/two/two.h
+++ b/two/two.h
@@ -31,7 +31,8 @@ public:
                   const char *check_id, SixPyObject *&check);
 
     const char *runCheck(SixPyObject *check);
-    void decref(SixPyObject *);
+    void decref(SixPyObject *obj);
+    void incref(SixPyObject *obj);
 
     // const API
     bool isInitialized() const;

--- a/two/two.h
+++ b/two/two.h
@@ -64,7 +64,7 @@ private:
 
     PyObject *_baseClass;
     PyPaths _pythonPaths;
-    PyThreadState *_state;
+    PyThreadState *_threadState;
 };
 
 #endif


### PR DESCRIPTION
# Split get_check

This PR split the `get_check` function into multiple functions to allow finer error handling and answer different use cases in the agent.