### PR TITLE
Make compile with GCC under windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ Release/
 *.dir/
 .vs/
 x64/
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "datadog_agent_six.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
         "datadog_agent_six.h": "c"
-    }
+    },
+    "editor.formatOnSave": true
 }

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -6,11 +6,19 @@ file(GLOB_RECURSE
 list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX ".CMakeFiles.")
 
 # Adding clang-format target if executable is found
-find_program(
-    CLANG_FORMAT
-    NAMES clang-format-8 clang-format
-    PATHS "/usr/local/bin"
-    )
+if(WIN32)
+    find_program(
+        CLANG_FORMAT
+        NAMES clang-format-8 clang-format
+        PATHS "c:\\devtools\\llvm\\bin"
+        )
+else()
+    find_program(
+        CLANG_FORMAT
+        NAMES clang-format-8 clang-format
+        PATHS "/usr/local/bin"
+        )
+endif()
 if(CLANG_FORMAT)
   add_custom_target(
     clang-format

--- a/common/aggregator.h
+++ b/common/aggregator.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_THREE_AGGREGATOR_H
 #define DATADOG_AGENT_SIX_THREE_AGGREGATOR_H

--- a/common/datadog_agent.h
+++ b/common/datadog_agent.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_DATADOG_AGENT_H
 #define DATADOG_AGENT_SIX_DATADOG_AGENT_H

--- a/common/sixstrings.h
+++ b/common/sixstrings.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_THREE_SIXSTRINGS_H
 #define DATADOG_AGENT_SIX_THREE_SIXSTRINGS_H

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -2,9 +2,10 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
 
 add_executable(demo main.c)
-
+include_directories(${CMAKE_SOURCE_DIR}/include)
 if(NOT WIN32)
     target_link_libraries(demo LINK_PUBLIC datadog-agent-six dl)
 else()
+    set_target_properties(demo PROPERTIES LINK_FLAGS -static)
     target_link_libraries(demo LINK_PUBLIC datadog-agent-six)
 endif()

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_H_INCLUDED
 #define DATADOG_AGENT_SIX_H_INCLUDED

--- a/include/six.h
+++ b/include/six.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_SIX_H
 #define DATADOG_AGENT_SIX_SIX_H

--- a/include/six_types.h
+++ b/include/six_types.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_TYPES_H
 #define DATADOG_AGENT_SIX_TYPES_H

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifdef _WIN32
 #    include <Windows.h>
@@ -55,7 +56,6 @@ six_t *make2() {
 
     return AS_TYPE(six_t, create());
 }
-
 
 six_t *make3() {
     // load the library

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -20,8 +20,8 @@
 #    define DATADOG_AGENT_TWO "libdatadog-agent-two.dylib"
 #    define DATADOG_AGENT_THREE "libdatadog-agent-three.dylib"
 #elif _WIN32
-#    define DATADOG_AGENT_TWO "datadog-agent-two.dll"
-#    define DATADOG_AGENT_THREE "datadog-agent-three.dll"
+#    define DATADOG_AGENT_TWO "libdatadog-agent-two.dll"
+#    define DATADOG_AGENT_THREE "libdatadog-agent-three.dll"
 #else
 #    error Platform not supported
 #endif
@@ -56,17 +56,6 @@ six_t *make2() {
     return AS_TYPE(six_t, create());
 }
 
-void destroy2(six_t *six) {
-    if (six_backend) {
-        // dlsym object destructor
-        destroy_t *destroy = (destroy_t *)GetProcAddress(six_backend, "destroy");
-        if (!destroy) {
-            std::cerr << "Unable to open 'two' destructor: " << GetLastError() << std::endl;
-            return;
-        }
-        destroy(AS_TYPE(Six, six));
-    }
-}
 
 six_t *make3() {
     // load the library
@@ -86,7 +75,7 @@ six_t *make3() {
     return AS_TYPE(six_t, create_three());
 }
 
-void destroy3(six_t *six) {
+void destroy(six_t *six) {
     if (six_backend) {
         // dlsym object destructor
         destroy_t *destroy = (destroy_t *)GetProcAddress(six_backend, "destroy");

--- a/six/six.cpp
+++ b/six/six.cpp
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #include <six.h>
 

--- a/three/CMakeLists.txt
+++ b/three/CMakeLists.txt
@@ -4,16 +4,24 @@ find_package (Python3 COMPONENTS Interpreter Development)
 project(datadog-agent-three VERSION 0.1.0 DESCRIPTION "CPython backend for the Datadog Agent")
 
 if(WIN32)
-# explicitly set the compiler flags to use the static C runtime (/MT(d) instead of the DLL
-# c runtime (/MD(d) so that we don't have to worry about redistributing the CRT).
+  if(MSVC)
 
-foreach(flag_var
-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-   if(${flag_var} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-   endif(${flag_var} MATCHES "/MD")
-endforeach(flag_var)
+    # explicitly set the compiler flags to use the static C runtime (/MT(d) instead of the DLL
+    # c runtime (/MD(d) so that we don't have to worry about redistributing the CRT).
+    foreach(flag_var
+            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif(${flag_var} MATCHES "/MD")
+    endforeach(flag_var)
+  else() # assume gnuC on windows
+    set(CMAKE_C_FLAGS "-D_hypot=hypot -DMS_WIN64")
+    set(CMAKE_CXX_FLAGS "-D_hypot=hypot -DMS_WIN64")
+    if(Python3_STDLIB)
+        string(REPLACE "\\" "\\\\" Python3_STDLIB ${Python3_STDLIB})
+    endif()
+  endif()
 endif()
 
 include(GNUInstallDirs)
@@ -25,6 +33,10 @@ add_library(datadog-agent-three SHARED
     ../common/aggregator.c
     ../common/datadog_agent.c
 )
+
+if(WIN32)
+  set_target_properties(datadog-agent-three PROPERTIES LINK_FLAGS -static)
+endif()
 
 add_compile_definitions(DATADOG_AGENT_THREE)
 target_include_directories(datadog-agent-three PRIVATE .)

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #include "three.h"
 
@@ -393,7 +394,8 @@ std::string Three::_fetchPythonError() const {
     PyObject *pvalue = NULL;
     PyObject *ptraceback = NULL;
 
-    // Fetch error and make sure exception values are normalized, as per python C API docs.
+    // Fetch error and make sure exception values are normalized, as per python C
+    // API docs.
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
     PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
 
@@ -418,7 +420,8 @@ std::string Three::_fetchPythonError() const {
             }
             Py_XDECREF(traceback);
         } else {
-            // If we reach this point, there was an error while formatting the exception
+            // If we reach this point, there was an error while formatting the
+            // exception
             ret_val = "can't format exception";
         }
     }

--- a/three/three.h
+++ b/three/three.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_THREE_H
 #define DATADOG_AGENT_SIX_THREE_H

--- a/two/CMakeLists.txt
+++ b/two/CMakeLists.txt
@@ -4,15 +4,22 @@ find_package (Python2 COMPONENTS Interpreter Development)
 project(datadog-agent-two VERSION 0.1.0 DESCRIPTION "CPython backend for the Datadog Agent")
 
 if(WIN32)
-# explicitly set the compiler flags to use the static C runtime (/MT(d) instead of the DLL
-# c runtime (/MD(d) so that we don't have to worry about redistributing the CRT).
-foreach(flag_var
-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-   if(${flag_var} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-   endif(${flag_var} MATCHES "/MD")
-endforeach(flag_var)
+  if(MSVC)
+
+    # explicitly set the compiler flags to use the static C runtime (/MT(d) instead of the DLL
+    # c runtime (/MD(d) so that we don't have to worry about redistributing the CRT).
+    foreach(flag_var
+            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif(${flag_var} MATCHES "/MD")
+    endforeach(flag_var)
+  else() # assume gnuC on windows
+    set(CMAKE_C_FLAGS "-D_hypot=hypot -DMS_WIN64")
+    set(CMAKE_CXX_FLAGS "-D_hypot=hypot -DMS_WIN64")
+    string(REPLACE "\\" "\\\\" Python2_STDLIB ${Python2_STDLIB})
+  endif()
 endif()
 
 include(GNUInstallDirs)
@@ -31,6 +38,10 @@ target_include_directories(datadog-agent-two PUBLIC
     ${CMAKE_SOURCE_DIR}/common
     ${Python2_INCLUDE_DIRS}
 )
+if(WIN32)
+  set_target_properties(datadog-agent-two PROPERTIES LINK_FLAGS -static)
+endif()
+
 target_link_libraries(datadog-agent-two ${Python2_LIBRARIES} datadog-agent-six)
 
 if(WIN32)

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #include "two.h"
 
@@ -291,7 +292,8 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module) {
             symbol_name = PyString_AsString(symbol);
         }
 
-        // get symbol instance. It's a new ref but in case of success we don't DecRef since we return it and the caller
+        // get symbol instance. It's a new ref but in case of success we don't
+        // DecRef since we return it and the caller
         // will be owner
         klass = PyObject_GetAttrString(module, symbol_name);
         if (klass == NULL) {
@@ -391,7 +393,8 @@ std::string Two::_fetchPythonError() {
     PyObject *pvalue = NULL;
     PyObject *ptraceback = NULL;
 
-    // Fetch error and make sure exception values are normalized, as per python C API docs.
+    // Fetch error and make sure exception values are normalized, as per python C
+    // API docs.
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
     PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
 
@@ -414,7 +417,8 @@ std::string Two::_fetchPythonError() {
             }
             Py_XDECREF(traceback);
         } else {
-            // If we reach this point, there was an error while formatting the exception
+            // If we reach this point, there was an error while formatting the
+            // exception
             ret_val = "can't format exception";
         }
     }

--- a/two/two.h
+++ b/two/two.h
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 #ifndef DATADOG_AGENT_SIX_TWO_H
 #define DATADOG_AGENT_SIX_TWO_H


### PR DESCRIPTION
As the title says; make `six` compile with the gcc toolchain rather than windows.

When we go to link it with `go` programs, those use gcc, so we need gcc linked libraries.

Also, made all of the DLLs static linked (for windows) so that we don't have to redistribute c runtime, pthreads, etc.