### PR TITLE
Fix get_config callback to work for every tests

### DIFF
--- a/test/datadog_agent/datadog_agent.go
+++ b/test/datadog_agent/datadog_agent.go
@@ -106,10 +106,18 @@ func getVersion(in **C.char) {
 
 //export getConfig
 func getConfig(key *C.char, in **C.char) {
-	m := message{C.GoString(key), "Hello", 123456}
-	b, _ := json.Marshal(m)
 
-	*in = C.CString(string(b))
+	goKey := C.GoString(key)
+	switch goKey {
+	case "log_level":
+		*in = C.CString("\"warning\"")
+	case "foo":
+		m := message{C.GoString(key), "Hello", 123456}
+		b, _ := json.Marshal(m)
+		*in = C.CString(string(b))
+	default:
+		*in = C.CString("null")
+	}
 }
 
 //export headers


### PR DESCRIPTION
Since tests are compiled at once we can only have 1 callback for getConfig