### PR TITLE
Add cgo_free callback

### DIFF
--- a/common/cgo_free.c
+++ b/common/cgo_free.c
@@ -16,7 +16,8 @@ void _set_cgo_free_cb(cb_cgo_free_t cb) {
 // free method to release memory allocated in the agent once we're done with
 // them.
 void cgo_free(void *ptr) {
-    if (cb_cgo_free == NULL || ptr == NULL)
+    if (cb_cgo_free == NULL || ptr == NULL) {
         return;
+    }
     cb_cgo_free(ptr);
 }

--- a/common/cgo_free.c
+++ b/common/cgo_free.c
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+#include "cgo_free.h"
+
+// these must be set by the Agent
+static cb_cgo_free_t cb_cgo_free = NULL;
+
+void _set_cgo_free_cb(cb_cgo_free_t cb) {
+    cb_cgo_free = cb;
+}
+
+// On windows we cannot free memory block from another DLL. Agent's Callbacks
+// will return memory block to free, this is why we need to a pointer to CGO
+// free method to release memory allocated in the agent once we're done with
+// them.
+void cgo_free(void *ptr) {
+    if (cb_cgo_free == NULL || ptr == NULL)
+        return;
+    cb_cgo_free(ptr);
+}

--- a/common/cgo_free.h
+++ b/common/cgo_free.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 void _set_cgo_free_cb(cb_cgo_free_t);
-void cgo_free(void *ptr);
+void DATADOG_AGENT_SIX_API cgo_free(void *ptr);
 
 #ifdef __cplusplus
 }

--- a/common/cgo_free.h
+++ b/common/cgo_free.h
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+#ifndef DATADOG_AGENT_SIX_CGO_FREE_H
+#define DATADOG_AGENT_SIX_CGO_FREE_H
+#include <six_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void _set_cgo_free_cb(cb_cgo_free_t);
+void cgo_free(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/datadog_agent_six.h
+++ b/include/datadog_agent_six.h
@@ -69,6 +69,9 @@ DATADOG_AGENT_SIX_API void set_set_external_tags_cb(six_t *, cb_set_external_tag
 // _UTIL
 DATADOG_AGENT_SIX_API void set_get_subprocess_output_cb(six_t *six, cb_get_subprocess_output_t cb);
 
+// CGO API
+DATADOG_AGENT_SIX_API void set_cgo_free_cb(six_t *, cb_cgo_free_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/six.h
+++ b/include/six.h
@@ -71,6 +71,9 @@ public:
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t) = 0;
 
+    // CGO API
+    virtual void setCGOFreeCb(cb_cgo_free_t) = 0;
+
 private:
     mutable std::string _error;
     mutable bool _errorFlag;

--- a/include/six_types.h
+++ b/include/six_types.h
@@ -89,6 +89,10 @@ typedef void (*cb_set_external_tags_t)(char *);
 // (argv, argc, raise, output)
 typedef void (*cb_get_subprocess_output_t)(char **, int, int, char **);
 
+// CGO API
+//
+typedef void (*cb_cgo_free_t)(void *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/six/api.cpp
+++ b/six/api.cpp
@@ -308,3 +308,10 @@ char *get_integration_list(six_t *six) {
 void set_get_subprocess_output_cb(six_t *six, cb_get_subprocess_output_t cb) {
     AS_TYPE(Six, six)->setSubprocessOutputCb(cb);
 }
+
+/*
+ * CGO API
+ */
+void set_cgo_free_cb(six_t *six, cb_cgo_free_t cb) {
+    AS_TYPE(Six, six)->setCGOFreeCb(cb);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,13 @@
 cmake_minimum_required(VERSION 3.12)
 
 set(PKGS
-    "./init/..."
+	"./init/..."
 	"./six/..."
 	"./aggregator/..."
 	"./datadog_agent/..."
-    "./util/..."
-    "./uutil/..."
+	"./util/..."
+	"./uutil/..."
+	"./common/..."
 )
 
 set(LIBS_PATH "${CMAKE_SOURCE_DIR}/six/:${CMAKE_SOURCE_DIR}/two/:${CMAKE_SOURCE_DIR}/three/")
@@ -14,7 +15,7 @@ set(LIBS_PATH "${CMAKE_SOURCE_DIR}/six/:${CMAKE_SOURCE_DIR}/two/:${CMAKE_SOURCE_
 if (NOT DISABLE_PYTHON2)
     add_custom_command(
         OUTPUT testPy2
-        COMMAND ${CMAKE_COMMAND} -E env TESTING_TWO="" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env TESTING_TWO="" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "two" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy2")
 endif()
@@ -22,7 +23,7 @@ endif()
 if (NOT DISABLE_PYTHON3)
     add_custom_command(
         OUTPUT testPy3
-        COMMAND ${CMAKE_COMMAND} -E env TESTING_THREE="" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env TESTING_THREE="" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "three" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy3")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ set(LIBS_PATH "${CMAKE_SOURCE_DIR}/six/:${CMAKE_SOURCE_DIR}/two/:${CMAKE_SOURCE_
 if (NOT DISABLE_PYTHON2)
     add_custom_command(
         OUTPUT testPy2
-        COMMAND ${CMAKE_COMMAND} -E env TESTING_TWO="" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "two" -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env TESTING_TWO="1" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "two" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy2")
 endif()
@@ -23,7 +23,7 @@ endif()
 if (NOT DISABLE_PYTHON3)
     add_custom_command(
         OUTPUT testPy3
-        COMMAND ${CMAKE_COMMAND} -E env TESTING_THREE="" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "three" -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env TESTING_THREE="1" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "three" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy3")
 endif()

--- a/test/common/cgo_free.go
+++ b/test/common/cgo_free.go
@@ -1,0 +1,64 @@
+package testcommon
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I../../include
+#cgo !windows LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
+#cgo windows LDFLAGS: -L../../six/ -ldatadog-agent-six -lstdc++ -static
+#include <datadog_agent_six.h>
+
+extern void c_callCgoFree(void *ptr);
+extern void cgoFree(void *);
+
+static void initCgoFreeTests(six_t *six) {
+	set_cgo_free_cb(six, cgoFree);
+}
+*/
+import "C"
+
+var (
+	six           *C.six_t
+	cgoFreeCalled bool
+	latestFreePtr unsafe.Pointer
+)
+
+func setUp() error {
+	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
+		six = C.make2()
+		if six == nil {
+			return fmt.Errorf("`make2` failed")
+		}
+	} else {
+		six = C.make3()
+		if six == nil {
+			return fmt.Errorf("`make3` failed")
+		}
+	}
+
+	C.initCgoFreeTests(six)
+
+	// Updates sys.path so testing Check can be found
+	C.add_python_path(six, C.CString("../python"))
+
+	if ok := C.init(six, nil); ok != 1 {
+		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
+	}
+
+	C.ensure_gil(six)
+	return nil
+}
+
+func callCgoFree(ptr unsafe.Pointer) {
+	C.c_callCgoFree(ptr)
+}
+
+//export cgoFree
+func cgoFree(ptr unsafe.Pointer) {
+	cgoFreeCalled = true
+	latestFreePtr = ptr
+}

--- a/test/common/cgo_free_test.go
+++ b/test/common/cgo_free_test.go
@@ -27,7 +27,7 @@ func TestCgoFree(t *testing.T) {
 	v := 21
 	callCgoFree(unsafe.Pointer(&v))
 	if cgoFreeCalled != true {
-		t.Errorf("freeing a pointer should haved called the cgoFree callback")
+		t.Errorf("freeing a pointer should have called the cgoFree callback")
 	}
 	if unsafe.Pointer(&v) != latestFreePtr {
 		t.Errorf("Freed pointer was not the same as the one given to the callback")

--- a/test/common/cgo_free_test.go
+++ b/test/common/cgo_free_test.go
@@ -1,0 +1,35 @@
+package testcommon
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"unsafe"
+)
+
+func TestMain(m *testing.M) {
+	err := setUp()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error setting up tests: %v", err)
+		os.Exit(-1)
+	}
+
+	ret := m.Run()
+	os.Exit(ret)
+}
+
+func TestCgoFree(t *testing.T) {
+	callCgoFree(nil)
+	if cgoFreeCalled != false {
+		t.Errorf("freeing NULL should not haved called the cgoFree callback")
+	}
+
+	v := 21
+	callCgoFree(unsafe.Pointer(&v))
+	if cgoFreeCalled != true {
+		t.Errorf("freeing a pointer should haved called the cgoFree callback")
+	}
+	if unsafe.Pointer(&v) != latestFreePtr {
+		t.Errorf("Freed pointer was not the same as the one given to the callback")
+	}
+}

--- a/test/common/cgo_free_three.go
+++ b/test/common/cgo_free_three.go
@@ -1,0 +1,17 @@
+// +build three
+
+package testcommon
+
+/*
+#cgo CFLAGS: -I../../common
+#cgo !windows LDFLAGS: -L../../three/ -ldatadog-agent-three
+#cgo windows LDFLAGS: -L../../three/ -ldatadog-agent-three.dll
+#include <cgo_free.h>
+
+extern void cgo_free(void *ptr);
+
+void c_callCgoFree(void *ptr) {
+	cgo_free(ptr);
+}
+*/
+import "C"

--- a/test/common/cgo_free_two.go
+++ b/test/common/cgo_free_two.go
@@ -1,0 +1,15 @@
+// +build two
+
+package testcommon
+
+/*
+#cgo CFLAGS: -I../../common
+#cgo !windows LDFLAGS: -L../../two/ -ldatadog-agent-two
+#cgo windows LDFLAGS: -L../../two/ -ldatadog-agent-two.dll
+#include <cgo_free.h>
+
+void c_callCgoFree(void *ptr) {
+	cgo_free(ptr);
+}
+*/
+import "C"

--- a/three/CMakeLists.txt
+++ b/three/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(datadog-agent-three SHARED
     ../common/datadog_agent.c
     ../common/util.c
     ../common/_util.c
+    ../common/cgo_free.c
 )
 
 if(WIN32)

--- a/three/three.cpp
+++ b/three/three.cpp
@@ -13,6 +13,7 @@ extern "C" {
 
 #include <_util.h>
 #include <aggregator.h>
+#include <cgo_free.h>
 #include <datadog_agent.h>
 #include <util.h>
 
@@ -545,6 +546,10 @@ void Three::setSetExternalTagsCb(cb_set_external_tags_t cb) {
 
 void Three::setSubprocessOutputCb(cb_get_subprocess_output_t cb) {
     _set_get_subprocess_output_cb(cb);
+}
+
+void Three::setCGOFreeCb(cb_cgo_free_t cb) {
+    _set_cgo_free_cb(cb);
 }
 
 // Python Helpers

--- a/three/three.h
+++ b/three/three.h
@@ -65,7 +65,7 @@ public:
     void setSubmitServiceCheckCb(cb_submit_service_check_t);
     void setSubmitEventCb(cb_submit_event_t);
 
-    // datadog_agent
+    // datadog_agent API
     void setGetVersionCb(cb_get_version_t);
     void setGetConfigCb(cb_get_config_t);
     void setHeadersCb(cb_headers_t);
@@ -76,6 +76,9 @@ public:
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);
+
+    // CGO API
+    void setCGOFreeCb(cb_cgo_free_t);
 
 private:
     PyObject *_importFrom(const char *module, const char *name);

--- a/two/CMakeLists.txt
+++ b/two/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(datadog-agent-two SHARED
     ../common/datadog_agent.c
     ../common/util.c
     ../common/_util.c
+    ../common/cgo_free.c
 )
 add_compile_definitions(DATADOG_AGENT_TWO)
 target_include_directories(datadog-agent-two PRIVATE .)

--- a/two/two.cpp
+++ b/two/two.cpp
@@ -13,6 +13,7 @@ extern "C" {
 
 #include <_util.h>
 #include <aggregator.h>
+#include <cgo_free.h>
 #include <datadog_agent.h>
 #include <util.h>
 
@@ -531,6 +532,10 @@ void Two::setSetExternalTagsCb(cb_set_external_tags_t cb) {
 
 void Two::setSubprocessOutputCb(cb_get_subprocess_output_t cb) {
     _set_get_subprocess_output_cb(cb);
+}
+
+void Two::setCGOFreeCb(cb_cgo_free_t cb) {
+    _set_cgo_free_cb(cb);
 }
 
 // Python Helpers

--- a/two/two.h
+++ b/two/two.h
@@ -51,7 +51,7 @@ public:
     void setSubmitServiceCheckCb(cb_submit_service_check_t);
     void setSubmitEventCb(cb_submit_event_t);
 
-    // datadog_agent
+    // datadog_agent API
     void setGetVersionCb(cb_get_version_t);
     void setGetConfigCb(cb_get_config_t);
     void setHeadersCb(cb_headers_t);
@@ -62,6 +62,9 @@ public:
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);
+
+    // CGO API
+    void setCGOFreeCb(cb_cgo_free_t);
 
 private:
     PyObject *_importFrom(const char *module, const char *name);


### PR DESCRIPTION
On windows we cannot free memory block from another DLL. Agent's
callbacks will return memory block to free, this is why we need to a
pointer to CGO free function in Six to release memory allocated in the
agent once we're done with them.