### PR TITLE
Stop using env vars to split tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ set(LIBS_PATH "${CMAKE_SOURCE_DIR}/six/:${CMAKE_SOURCE_DIR}/two/:${CMAKE_SOURCE_
 if (NOT DISABLE_PYTHON2)
     add_custom_command(
         OUTPUT testPy2
-        COMMAND ${CMAKE_COMMAND} -E env TESTING_TWO="1" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "two" -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "two" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy2")
 endif()
@@ -24,7 +24,7 @@ endif()
 if (NOT DISABLE_PYTHON3)
     add_custom_command(
         OUTPUT testPy3
-        COMMAND ${CMAKE_COMMAND} -E env TESTING_THREE="1" DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "three" -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "three" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy3")
 endif()

--- a/test/aggregator/aggregator.go
+++ b/test/aggregator/aggregator.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"unsafe"
+
+	common "../common"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -65,16 +67,9 @@ func resetOuputValues() {
 }
 
 func setUp() error {
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six = (*C.six_t)(common.GetSix())
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	C.initAggregatorTests(six)

--- a/test/common/cgo_free.go
+++ b/test/common/cgo_free.go
@@ -2,7 +2,6 @@ package testcommon
 
 import (
 	"fmt"
-	"os"
 	"unsafe"
 )
 
@@ -28,16 +27,9 @@ var (
 )
 
 func setUp() error {
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six = GetSix()
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	C.initCgoFreeTests(six)

--- a/test/common/common_three.go
+++ b/test/common/common_three.go
@@ -1,0 +1,18 @@
+// +build three
+
+package testcommon
+
+// #cgo CFLAGS: -I../../include
+// #cgo !windows LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
+// #cgo windows LDFLAGS: -L../../six/ -ldatadog-agent-six -lstdc++ -static
+// #include <datadog_agent_six.h>
+//
+import "C"
+
+// UsingTwo states whether we're using Two as backend
+const UsingTwo bool = false
+
+// GetSix returns a Six instance using Three
+func GetSix() *C.six_t {
+	return C.make3()
+}

--- a/test/common/common_two.go
+++ b/test/common/common_two.go
@@ -1,0 +1,18 @@
+// +build two
+
+package testcommon
+
+// #cgo CFLAGS: -I../../include
+// #cgo !windows LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
+// #cgo windows LDFLAGS: -L../../six/ -ldatadog-agent-six -lstdc++ -static
+// #include <datadog_agent_six.h>
+//
+import "C"
+
+// UsingTwo states whether we're using Two as backend
+const UsingTwo bool = true
+
+// GetSix returns a Six instance using Two
+func GetSix() *C.six_t {
+	return C.make2()
+}

--- a/test/datadog_agent/datadog_agent.go
+++ b/test/datadog_agent/datadog_agent.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+
+	common "../common"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -44,16 +46,9 @@ type message struct {
 }
 
 func setUp() error {
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six = (*C.six_t)(common.GetSix())
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	var err error

--- a/test/init/init.go
+++ b/test/init/init.go
@@ -2,7 +2,8 @@ package testinit
 
 import (
 	"fmt"
-	"os"
+
+	common "../common"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -13,18 +14,9 @@ import (
 import "C"
 
 func runInit() error {
-	var six *C.six_t
-
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six := (*C.six_t)(common.GetSix())
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	// Updates sys.path so testing Check can be found

--- a/test/six/six.go
+++ b/test/six/six.go
@@ -13,6 +13,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	common "../common"
 )
 
 var (
@@ -21,16 +23,9 @@ var (
 )
 
 func setUp() error {
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six = (*C.six_t)(common.GetSix())
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	var err error

--- a/test/six/six_test.go
+++ b/test/six/six_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	common "../common"
 )
 
 func TestMain(m *testing.M) {
@@ -25,7 +27,7 @@ func TestMain(m *testing.M) {
 func TestGetVersion(t *testing.T) {
 	ver := getVersion()
 	prefix := "3."
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
+	if common.UsingTwo {
 		prefix = "2.7."
 	}
 
@@ -53,7 +55,7 @@ with open(r'%s', 'w') as f:
 func TestGetError(t *testing.T) {
 	errorStr := getError()
 	expected := "unable to import module 'foo': No module named 'foo'"
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
+	if common.UsingTwo {
 		expected = "unable to import module 'foo': No module named foo"
 	}
 	if errorStr != expected {

--- a/test/tagger/tagger.go
+++ b/test/tagger/tagger.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	common "../common"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -24,16 +26,9 @@ var (
 )
 
 func setUp() error {
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six = (*C.six_t)(common.GetSix())
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	var err error

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	common "../common"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -31,16 +33,9 @@ type message struct {
 }
 
 func setUp() error {
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six = (*C.six_t)(common.GetSix())
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	var err error

--- a/test/uutil/uutil.go
+++ b/test/uutil/uutil.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	common "../common"
 )
 
 // #cgo CFLAGS: -I../../include
-// #cgo linux LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
+// #cgo !windows LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
 // #cgo windows LDFLAGS: -L../../six/ -ldatadog-agent-six -lstdc++ -static
 // #include <datadog_agent_six.h>
 //
@@ -24,16 +26,9 @@ var (
 )
 
 func setUp() error {
-	if _, ok := os.LookupEnv("TESTING_TWO"); ok {
-		six = C.make2()
-		if six == nil {
-			return fmt.Errorf("`make2` failed")
-		}
-	} else {
-		six = C.make3()
-		if six == nil {
-			return fmt.Errorf("`make3` failed")
-		}
+	six = (*C.six_t)(common.GetSix())
+	if six == nil {
+		return fmt.Errorf("make failed")
 	}
 
 	var err error


### PR DESCRIPTION
We used to rely on env vars to avoid duplicated code in the tests and run the same bits against Python2 and Python3. Recently we added build flags on top of that, this PR removes the need of env vars, solely relying on build flags to split the tests.