### PR TITLE
Push artifacts to GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,3 +19,39 @@ jobs:
           name: Test
           command: |
             make -C test run
+      - run:
+          name: Artifacts
+          command: |
+            mkdir ./dist
+            mv ./six/libdatadog-agent-six.so* ./three/libdatadog-agent-three.so ./two/libdatadog-agent-two.so ./dist/
+            tar -C ./dist -czf datadog-agent-six.tgz .
+      - store_artifacts:
+          path: ./datadog-agent-six.tgz
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./datadog-agent-six.tgz
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:latest
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./datadog-agent-six.tgz
+
+workflows:
+  version: 2
+  build_and_release:
+    jobs:
+      - build
+      - publish-github-release:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,10 @@ workflows:
   version: 2
   build_and_release:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
       - publish-github-release:
           requires:
             - build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,22 @@ test_script:
   - "%PIP3% install -r integrations-core/directory/requirements.in"
   - "%PIP3% install integrations-core/datadog_checks_base integrations-core/directory"
   - bash -c "./bin/demo 3"
+  # archive binaries
+  - 7z a "datadog-agent-six.zip" "./bin/*.dll" "./six/libdatadog-agent-six.a"
+
+artifacts:
+  - path: "datadog-agent-six.zip"
+
+deploy:
+  provider: GitHub
+  description: "Datadog Agent Six"
+  force_update: true
+  auth_token:
+    secure: 89PR5NjCO2AajmsJBlM/lr5EpYMefvZaVve8Tkyxu2X9xqVcxKGcq25C9ywMySDI
+  artifact: "datadog-agent-six.zip"
+  on:
+    # deploy on tag push only
+    APPVEYOR_REPO_TAG: true
 
 # uncomment to debug builds
 # on_finish:


### PR DESCRIPTION
To ease local development, make binaries for linux x86_64 publicly available on GitHub